### PR TITLE
Version IdP API under /v1 + split public/admin OpenAPI

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/hydra-accept-login": {
+    "/v1/hydra-accept-login": {
       "post": {
         "operationId": "acceptHydraLogin",
         "summary": "Accept a Hydra login challenge for the signed-in user",
@@ -33,7 +33,7 @@
         ]
       }
     },
-    "/hydra-accept-consent": {
+    "/v1/hydra-accept-consent": {
       "post": {
         "operationId": "acceptHydraConsent",
         "summary": "Accept a Hydra consent challenge for the signed-in user",
@@ -65,7 +65,7 @@
         ]
       }
     },
-    "/admin/users": {
+    "/v1/admin/users": {
       "get": {
         "operationId": "AdminUsersController_list",
         "summary": "List all platform users (cursor-paginated)",
@@ -166,7 +166,7 @@
         ]
       }
     },
-    "/admin/users/{id}": {
+    "/v1/admin/users/{id}": {
       "get": {
         "operationId": "AdminUsersController_get",
         "summary": "Get a single user by Kratos identity id",
@@ -300,7 +300,7 @@
         ]
       }
     },
-    "/admin/users/{id}/state": {
+    "/v1/admin/users/{id}/state": {
       "patch": {
         "operationId": "AdminUsersController_setState",
         "summary": "Activate or deactivate a user identity",
@@ -355,7 +355,7 @@
         ]
       }
     },
-    "/admin/users/{id}/recovery-link": {
+    "/v1/admin/users/{id}/recovery-link": {
       "post": {
         "operationId": "AdminUsersController_recoveryLink",
         "summary": "Generate a recovery link for a user",
@@ -400,7 +400,7 @@
         ]
       }
     },
-    "/me/permissions": {
+    "/v1/me/permissions": {
       "get": {
         "operationId": "MeController_permissions",
         "summary": "Resolve the caller's Platform-level Keto permissions",

--- a/api/scripts/generate-openapi.ts
+++ b/api/scripts/generate-openapi.ts
@@ -1,5 +1,6 @@
 // api/scripts/generate-openapi.ts
 import { NestFactory } from '@nestjs/core';
+import { VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule, OpenAPIObject } from '@nestjs/swagger';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
@@ -88,6 +89,8 @@ function filterByTags(doc: OpenAPIObject): OpenAPIObject {
 
 async function generate() {
   const app = await NestFactory.create(AppModule, { logger: false });
+  // Must match main.ts: URI versioning so /v1/... paths appear in the spec.
+  app.enableVersioning({ type: VersioningType.URI });
   const config = new DocumentBuilder()
     .setTitle('Nova ID API')
     .setDescription('Self-hosted central IdP BFF — Ory consolidation layer')

--- a/api/scripts/generate-openapi.ts
+++ b/api/scripts/generate-openapi.ts
@@ -1,91 +1,14 @@
 // api/scripts/generate-openapi.ts
 import { NestFactory } from '@nestjs/core';
 import { VersioningType } from '@nestjs/common';
-import { DocumentBuilder, SwaggerModule, OpenAPIObject } from '@nestjs/swagger';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { AppModule } from '../src/app.module';
+import { filterByTags } from '../src/common/openapi-filter';
 
 /** Tags whose operations belong to the IdP client surface (ADR-0001). */
 const ALLOWED_TAGS = new Set(['admin', 'me', 'auth']);
-
-/** Collect all $ref values pointing to #/components/schemas/<Name>. */
-function collectRefs(node: unknown, acc: Set<string>): void {
-  if (!node || typeof node !== 'object') return;
-  if (Array.isArray(node)) {
-    node.forEach((n) => collectRefs(n, acc));
-    return;
-  }
-  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-    if (k === '$ref' && typeof v === 'string') {
-      const m = v.match(/^#\/components\/schemas\/(.+)$/);
-      if (m) acc.add(m[1]);
-    } else {
-      collectRefs(v, acc);
-    }
-  }
-}
-
-/**
- * Prune components.schemas to only those reachable (transitively via $ref)
- * from the kept paths. Cycles are handled via a visited set.
- * securitySchemes and other components.* maps are left untouched.
- */
-function pruneSchemas(doc: OpenAPIObject): OpenAPIObject {
-  const schemas = (doc.components?.schemas ?? {}) as Record<string, unknown>;
-  const reachable = new Set<string>();
-
-  // Seed: all $refs in the kept paths
-  collectRefs(doc.paths, reachable);
-
-  // Transitively follow $refs inside each reachable schema
-  const work = [...reachable];
-  const visited = new Set<string>();
-  while (work.length) {
-    const name = work.pop()!;
-    if (visited.has(name)) continue;
-    visited.add(name);
-    const schema = schemas[name];
-    const before = reachable.size;
-    collectRefs(schema, reachable);
-    if (reachable.size !== before) {
-      // new names were added — push them onto the worklist
-      for (const r of reachable) {
-        if (!visited.has(r)) work.push(r);
-      }
-    }
-  }
-
-  const kept: Record<string, unknown> = {};
-  for (const name of Object.keys(schemas)) {
-    if (reachable.has(name)) kept[name] = schemas[name];
-  }
-
-  return { ...doc, components: { ...doc.components, schemas: kept } };
-}
-
-function filterByTags(doc: OpenAPIObject): OpenAPIObject {
-  const paths = doc.paths ?? {};
-  const kept: typeof paths = {};
-  const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace'] as const;
-
-  for (const [route, item] of Object.entries(paths)) {
-    if (!item) continue;
-    const keptItem: Record<string, unknown> = {};
-    for (const method of HTTP_METHODS) {
-      const op = (item as Record<string, any>)[method];
-      if (!op) continue;
-      const tags: string[] = op.tags ?? [];
-      if (tags.some((t) => ALLOWED_TAGS.has(t))) {
-        keptItem[method] = op;
-      }
-    }
-    if (Object.keys(keptItem).length > 0) {
-      kept[route] = keptItem as (typeof paths)[string];
-    }
-  }
-  return { ...doc, paths: kept };
-}
 
 async function generate() {
   const app = await NestFactory.create(AppModule, { logger: false });
@@ -102,7 +25,7 @@ async function generate() {
     .build();
 
   const full = SwaggerModule.createDocument(app, config);
-  const filtered = pruneSchemas(filterByTags(full));
+  const filtered = filterByTags(full, ALLOWED_TAGS);
 
   const outPath = join(__dirname, '..', 'openapi.json');
   writeFileSync(outPath, JSON.stringify(filtered, null, 2) + '\n');

--- a/api/src/admin/admin-users.controller.ts
+++ b/api/src/admin/admin-users.controller.ts
@@ -31,7 +31,7 @@ import { RecoveryLinkResponseDto } from './dto/recovery-link-response.dto';
 @ApiTags('admin')
 @ApiBearerAuth('oathkeeper-id-token')
 @UseGuards(PlatformManageUsersGuard)
-@Controller('admin/users')
+@Controller({ path: 'admin/users', version: '1' })
 export class AdminUsersController {
   constructor(private readonly kratos: KratosAdminService) {}
 

--- a/api/src/app.controller.ts
+++ b/api/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, Version } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBody, ApiOkResponse } from '@nestjs/swagger';
 import { AppService } from './app.service';
 import { Public } from './decorators/public.decorator';
@@ -33,6 +33,7 @@ export class AppController {
   @ApiOperation({ operationId: 'acceptHydraLogin', summary: 'Accept a Hydra login challenge for the signed-in user' })
   @ApiBody({ type: AcceptHydraLoginDto })
   @ApiOkResponse({ type: HydraRedirectResponseDto })
+  @Version('1')
   @Post('hydra-accept-login')
   async acceptHydraLogin(
     @GetUser() user: AuthenticatedUser,
@@ -45,6 +46,7 @@ export class AppController {
   @ApiOperation({ operationId: 'acceptHydraConsent', summary: 'Accept a Hydra consent challenge for the signed-in user' })
   @ApiBody({ type: AcceptHydraConsentDto })
   @ApiOkResponse({ type: HydraRedirectResponseDto })
+  @Version('1')
   @Post('hydra-accept-consent')
   async acceptHydraConsent(
     @GetUser() user: AuthenticatedUser,

--- a/api/src/common/openapi-filter.ts
+++ b/api/src/common/openapi-filter.ts
@@ -1,0 +1,61 @@
+import { OpenAPIObject } from '@nestjs/swagger';
+
+export const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace'] as const;
+
+/** Collect all $ref values pointing to #/components/schemas/<Name>. */
+export function collectRefs(node: unknown, acc: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) { node.forEach((n) => collectRefs(n, acc)); return; }
+  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+    if (k === '$ref' && typeof v === 'string') {
+      const m = v.match(/^#\/components\/schemas\/(.+)$/);
+      if (m) acc.add(m[1]);
+    } else { collectRefs(v, acc); }
+  }
+}
+
+/**
+ * Prune components.schemas to only those transitively reachable via $ref
+ * from the kept paths. securitySchemes and other component maps are preserved.
+ */
+export function pruneSchemas(doc: OpenAPIObject): OpenAPIObject {
+  const schemas = (doc.components?.schemas ?? {}) as Record<string, unknown>;
+  const reachable = new Set<string>();
+  collectRefs(doc.paths, reachable);
+  const work = [...reachable];
+  const visited = new Set<string>();
+  while (work.length) {
+    const name = work.pop()!;
+    if (visited.has(name)) continue;
+    visited.add(name);
+    const before = reachable.size;
+    collectRefs(schemas[name], reachable);
+    if (reachable.size !== before) {
+      for (const r of reachable) { if (!visited.has(r)) work.push(r); }
+    }
+  }
+  const kept: Record<string, unknown> = {};
+  for (const name of Object.keys(schemas)) { if (reachable.has(name)) kept[name] = schemas[name]; }
+  return { ...doc, components: { ...doc.components, schemas: kept } };
+}
+
+/**
+ * Return a new doc containing only paths whose operations carry at least one
+ * of the given tags. Automatically calls pruneSchemas on the result.
+ */
+export function filterByTags(doc: OpenAPIObject, allowedTags: Set<string>): OpenAPIObject {
+  const paths = doc.paths ?? {};
+  const kept: typeof paths = {};
+  for (const [route, item] of Object.entries(paths)) {
+    if (!item) continue;
+    const keptItem: Record<string, unknown> = {};
+    for (const method of HTTP_METHODS) {
+      const op = (item as Record<string, any>)[method];
+      if (!op) continue;
+      const opTags: string[] = op.tags ?? [];
+      if (opTags.some((t) => allowedTags.has(t))) keptItem[method] = op;
+    }
+    if (Object.keys(keptItem).length > 0) kept[route] = keptItem as (typeof paths)[string];
+  }
+  return pruneSchemas({ ...doc, paths: kept });
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,9 +1,66 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, VersioningType } from '@nestjs/common';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { DocumentBuilder, SwaggerModule, OpenAPIObject } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { WinstonLogger } from './common/logger';
+
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace'] as const;
+
+/** Collect all $ref values pointing to #/components/schemas/<Name>. */
+function collectRefs(node: unknown, acc: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) { node.forEach((n) => collectRefs(n, acc)); return; }
+  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+    if (k === '$ref' && typeof v === 'string') {
+      const m = v.match(/^#\/components\/schemas\/(.+)$/);
+      if (m) acc.add(m[1]);
+    } else { collectRefs(v, acc); }
+  }
+}
+
+/**
+ * Prune components.schemas to only those transitively reachable via $ref
+ * from the kept paths. securitySchemes and other component maps are preserved.
+ */
+function pruneSchemas(doc: OpenAPIObject): OpenAPIObject {
+  const schemas = (doc.components?.schemas ?? {}) as Record<string, unknown>;
+  const reachable = new Set<string>();
+  collectRefs(doc.paths, reachable);
+  const work = [...reachable];
+  const visited = new Set<string>();
+  while (work.length) {
+    const name = work.pop()!;
+    if (visited.has(name)) continue;
+    visited.add(name);
+    const before = reachable.size;
+    collectRefs(schemas[name], reachable);
+    if (reachable.size !== before) {
+      for (const r of reachable) { if (!visited.has(r)) work.push(r); }
+    }
+  }
+  const kept: Record<string, unknown> = {};
+  for (const name of Object.keys(schemas)) { if (reachable.has(name)) kept[name] = schemas[name]; }
+  return { ...doc, components: { ...doc.components, schemas: kept } };
+}
+
+/** Return a new doc containing only paths whose operations carry at least one of the given tags. */
+function filterByTags(doc: OpenAPIObject, tags: Set<string>): OpenAPIObject {
+  const paths = doc.paths ?? {};
+  const kept: typeof paths = {};
+  for (const [route, item] of Object.entries(paths)) {
+    if (!item) continue;
+    const keptItem: Record<string, unknown> = {};
+    for (const method of HTTP_METHODS) {
+      const op = (item as Record<string, any>)[method];
+      if (!op) continue;
+      const opTags: string[] = op.tags ?? [];
+      if (opTags.some((t) => tags.has(t))) keptItem[method] = op;
+    }
+    if (Object.keys(keptItem).length > 0) kept[route] = keptItem as (typeof paths)[string];
+  }
+  return pruneSchemas({ ...doc, paths: kept });
+}
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule, {
@@ -48,19 +105,47 @@ async function bootstrap() {
         }),
     );
 
-    // Swagger OpenAPI documentation
-    const swaggerConfig = new DocumentBuilder()
+    // ── Swagger / OpenAPI ─────────────────────────────────────────────────────
+    // Build one full document, derive two tag-filtered views:
+    //
+    //   /docs         + /docs-json        PUBLIC  (tags: auth, me)
+    //   /docs/admin   + /docs/admin-json  ADMIN   (tag: admin)
+    //
+    // Security posture: the BFF container has zero host-published ports
+    // (docker-compose.yml, A0.4) and no Oathkeeper rule forwards /docs* to
+    // the BFF.  Neither endpoint is reachable from outside the Docker network.
+    // The tag split still matters: /docs served to legitimate callers contains
+    // zero admin operation shapes, so accidental leakage via misconfigured
+    // future gateway rules is limited to the public surface.
+    const bearerAuth = { type: 'http' as const, scheme: 'bearer', bearerFormat: 'JWT' };
+
+    const fullConfig = new DocumentBuilder()
         .setTitle('Nova ID API')
         .setDescription('Self-hosted central IdP BFF — Ory consolidation layer')
         .setVersion('1.0')
-        .addBearerAuth(
-            { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
-            'oathkeeper-id-token',
-        )
+        .addBearerAuth(bearerAuth, 'oathkeeper-id-token')
         .build();
-    const document = SwaggerModule.createDocument(app, swaggerConfig);
-    SwaggerModule.setup('docs', app, document, {
+    const fullDocument = SwaggerModule.createDocument(app, fullConfig);
+
+    // PUBLIC doc — auth + me tags only (zero /admin paths)
+    const publicDocument = filterByTags(fullDocument, new Set(['auth', 'me']));
+    SwaggerModule.setup('docs', app, publicDocument, {
         swaggerOptions: { persistAuthorization: true },
+        jsonDocumentUrl: 'docs-json',
+    });
+
+    // ADMIN doc — admin tag only; not routed via gateway (internal surface)
+    const adminDocument = {
+        ...filterByTags(fullDocument, new Set(['admin'])),
+        info: {
+            title: 'Nova ID Admin API',
+            description: 'Nova ID BFF — Platform-admin operations (internal surface, not publicly routed)',
+            version: '1.0',
+        },
+    } as OpenAPIObject;
+    SwaggerModule.setup('docs/admin', app, adminDocument, {
+        swaggerOptions: { persistAuthorization: true },
+        jsonDocumentUrl: 'docs/admin-json',
     });
 
     const port = process.env.PORT || 8080;

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
@@ -16,6 +16,11 @@ async function bootstrap() {
     // (and therefore @nestjs/throttler) reads req.ip from that header instead
     // of the socket address (which is always the gateway's container IP).
     app.getHttpAdapter().getInstance().set('trust proxy', 1);
+
+    // URI versioning: /v1/... for IdP business endpoints.
+    // No global defaultVersion — unversioned controllers (health, public, demo)
+    // remain accessible at their existing paths (version-neutral).
+    app.enableVersioning({ type: VersioningType.URI });
 
     // Security headers — disable CSP so Swagger UI (inline scripts/styles) loads correctly.
     // All other helmet defaults (X-Frame-Options, X-Content-Type-Options, etc.) remain active.

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -4,63 +4,7 @@ import { DocumentBuilder, SwaggerModule, OpenAPIObject } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { WinstonLogger } from './common/logger';
-
-const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace'] as const;
-
-/** Collect all $ref values pointing to #/components/schemas/<Name>. */
-function collectRefs(node: unknown, acc: Set<string>): void {
-  if (!node || typeof node !== 'object') return;
-  if (Array.isArray(node)) { node.forEach((n) => collectRefs(n, acc)); return; }
-  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-    if (k === '$ref' && typeof v === 'string') {
-      const m = v.match(/^#\/components\/schemas\/(.+)$/);
-      if (m) acc.add(m[1]);
-    } else { collectRefs(v, acc); }
-  }
-}
-
-/**
- * Prune components.schemas to only those transitively reachable via $ref
- * from the kept paths. securitySchemes and other component maps are preserved.
- */
-function pruneSchemas(doc: OpenAPIObject): OpenAPIObject {
-  const schemas = (doc.components?.schemas ?? {}) as Record<string, unknown>;
-  const reachable = new Set<string>();
-  collectRefs(doc.paths, reachable);
-  const work = [...reachable];
-  const visited = new Set<string>();
-  while (work.length) {
-    const name = work.pop()!;
-    if (visited.has(name)) continue;
-    visited.add(name);
-    const before = reachable.size;
-    collectRefs(schemas[name], reachable);
-    if (reachable.size !== before) {
-      for (const r of reachable) { if (!visited.has(r)) work.push(r); }
-    }
-  }
-  const kept: Record<string, unknown> = {};
-  for (const name of Object.keys(schemas)) { if (reachable.has(name)) kept[name] = schemas[name]; }
-  return { ...doc, components: { ...doc.components, schemas: kept } };
-}
-
-/** Return a new doc containing only paths whose operations carry at least one of the given tags. */
-function filterByTags(doc: OpenAPIObject, tags: Set<string>): OpenAPIObject {
-  const paths = doc.paths ?? {};
-  const kept: typeof paths = {};
-  for (const [route, item] of Object.entries(paths)) {
-    if (!item) continue;
-    const keptItem: Record<string, unknown> = {};
-    for (const method of HTTP_METHODS) {
-      const op = (item as Record<string, any>)[method];
-      if (!op) continue;
-      const opTags: string[] = op.tags ?? [];
-      if (opTags.some((t) => tags.has(t))) keptItem[method] = op;
-    }
-    if (Object.keys(keptItem).length > 0) kept[route] = keptItem as (typeof paths)[string];
-  }
-  return pruneSchemas({ ...doc, paths: kept });
-}
+import { filterByTags } from './common/openapi-filter';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule, {

--- a/api/src/me/me.controller.ts
+++ b/api/src/me/me.controller.ts
@@ -6,7 +6,7 @@ import { PermissionsResponseDto } from './dto/permissions-response.dto';
 
 @ApiTags('me')
 @ApiBearerAuth('oathkeeper-id-token')
-@Controller('me')
+@Controller({ path: 'me', version: '1' })
 export class MeController {
   constructor(private readonly keto: KetoService) {}
 

--- a/config/oathkeeper/rules.local.json
+++ b/config/oathkeeper/rules.local.json
@@ -426,7 +426,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/(hydra-accept-login|hydra-accept-consent)>",
+      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/v1/(hydra-accept-login|hydra-accept-consent)>",
       "methods": ["POST", "OPTIONS"]
     },
     "authenticators": [
@@ -492,7 +492,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/(me/permissions|admin(?!-))(/.*)?>",
+      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/v1/(me/permissions|admin(?!-))(/.*)?>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [

--- a/config/oathkeeper/rules.local.json
+++ b/config/oathkeeper/rules.local.json
@@ -49,38 +49,6 @@
     ]
   },
   {
-    "id": "kratos-admin-recovery-link",
-    "upstream": {
-      "preserve_host": false,
-      "strip_path": "/api",
-      "url": "http://kratos:4434"
-    },
-    "match": {
-      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/admin/recovery/link.*>",
-      "methods": ["POST"]
-    },
-    "authenticators": [{ "handler": "cookie_session" }],
-    "authorizer": {
-      "handler": "remote_json",
-      "config": {
-        "remote": "http://keto:4466/relation-tuples/check",
-        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"manage_users\",\"subject_id\":\"user:{{ print .Subject }}\"}",
-        "forward_response_headers_to_upstream": ["Content-Type"]
-      }
-    },
-    "mutators": [
-      {
-        "handler": "header",
-        "config": {
-          "headers": {
-            "X-User-ID": "{{ print .Subject }}",
-            "X-User-Email": "{{ print .Extra.identity.traits.email }}"
-          }
-        }
-      }
-    ]
-  },
-  {
     "id": "oauth2-public",
     "upstream": {
       "preserve_host": false,

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -48,37 +48,6 @@
     ]
   },
   {
-    "id": "kratos-admin-recovery-link",
-    "upstream": {
-      "preserve_host": false,
-      "url": "http://kratos:4434"
-    },
-    "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/admin/recovery/link.*>",
-      "methods": ["POST"]
-    },
-    "authenticators": [{ "handler": "cookie_session" }],
-    "authorizer": {
-      "handler": "remote_json",
-      "config": {
-        "remote": "http://keto:4466/relation-tuples/check",
-        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"manage_users\",\"subject_id\":\"user:{{ print .Subject }}\"}",
-        "forward_response_headers_to_upstream": ["Content-Type"]
-      }
-    },
-    "mutators": [
-      {
-        "handler": "header",
-        "config": {
-          "headers": {
-            "X-User-ID": "{{ print .Subject }}",
-            "X-User-Email": "{{ print .Extra.identity.traits.email }}"
-          }
-        }
-      }
-    ]
-  },
-  {
     "id": "hydra-public",
     "upstream": {
       "preserve_host": false,

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -311,7 +311,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(hydra-accept-login|hydra-accept-consent)>",
+      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(hydra-accept-login|hydra-accept-consent)>",
       "methods": ["POST", "OPTIONS"]
     },
     "authenticators": [
@@ -340,7 +340,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(me/permissions|admin(?!-))(/.*)?>",
+      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(me/permissions|admin(?!-))(/.*)?>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [


### PR DESCRIPTION
## A2 hardening — PR 2 of 4 (phases 4–5)

- **`/v1` URI versioning (surgical):** `enableVersioning({type: URI})` with `@Version('1')` on the IdP business surface only — `AdminUsersController`, `MeController`, and the two `hydra-accept` methods. `health`/`public` and the entire demo `/api-test/*` surface stay version-neutral. Gateway rules route `/api/v1/...` (strip `/api` → `/v1/...` reaches Nest); the generated client baseURL stays `/api` and its paths carry `/v1` → effective `/api/v1/...`. Old unversioned IdP paths now 404. Carlos will consume `/v1` from real services.
- **OpenAPI split:** a PUBLIC doc (`/docs`, tags `auth`+`me`) and an ADMIN doc (`/docs/admin`, tag `admin`). Neither is routed through the gateway and the BFF has no host ports — admin spec is not publicly exposed (defense-in-depth). Filter helpers extracted to a shared `api/src/common/openapi-filter.ts` (DRY).
- **Removed orphaned `kratos-admin-recovery-link` gateway bypass:** recovery-link is now owned by the BFF (`/v1/admin/users/{id}/recovery-link`); the direct-to-Kratos rule was dead and is deleted (both rule files).

Reviewed + re-reviewed (opus): zero blockers/warnings/nits. 73 unit tests pass; full gateway↔client↔BFF path coherence verified live (old paths 404, `/v1` 401 unauth, demo unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)