### PR TITLE
Route SPA logging through dev-only logger; stop logging error objects

### DIFF
--- a/frontend-admin/src/composables/useHydra.ts
+++ b/frontend-admin/src/composables/useHydra.ts
@@ -3,6 +3,7 @@
 // NOTE: This is OUTSIDE the BFF surface (calls Hydra Admin via the gateway, not
 // the Nest BFF), so it intentionally keeps hand-rolled fetch — it is not part of
 // the generated @nova-id/api-client.
+import { logger, errMessage } from '../utils/logger'
 const oathkeeperUrl = import.meta.env.VITE_OATHKEEPER_URL || '/api'
 const hydraAdminUrl = `${oathkeeperUrl}/hydra-admin`
 
@@ -33,7 +34,7 @@ export async function listClients(): Promise<OAuthClient[]> {
 
     return await response.json()
   } catch (error) {
-    console.error('Error listing clients:', error)
+    logger.error('Error listing clients:', errMessage(error))
     throw error
   }
 }
@@ -57,7 +58,7 @@ export async function getClient(clientId: string): Promise<OAuthClient> {
 
     return await response.json()
   } catch (error) {
-    console.error('Error getting client:', error)
+    logger.error('Error getting client:', errMessage(error))
     throw error
   }
 }
@@ -83,7 +84,7 @@ export async function createClient(clientData: Record<string, unknown>): Promise
 
     return await response.json()
   } catch (error) {
-    console.error('Error creating client:', error)
+    logger.error('Error creating client:', errMessage(error))
     throw error
   }
 }
@@ -109,7 +110,7 @@ export async function updateClient(clientId: string, clientData: Record<string, 
 
     return await response.json()
   } catch (error) {
-    console.error('Error updating client:', error)
+    logger.error('Error updating client:', errMessage(error))
     throw error
   }
 }
@@ -133,7 +134,7 @@ export async function deleteClient(clientId: string): Promise<boolean> {
 
     return true
   } catch (error) {
-    console.error('Error deleting client:', error)
+    logger.error('Error deleting client:', errMessage(error))
     throw error
   }
 }
@@ -157,7 +158,7 @@ export async function listAccessTokens(): Promise<unknown> {
 
     return await response.json()
   } catch (error) {
-    console.error('Error listing tokens:', error)
+    logger.error('Error listing tokens:', errMessage(error))
     throw error
   }
 }

--- a/frontend-admin/src/composables/usePermissions.ts
+++ b/frontend-admin/src/composables/usePermissions.ts
@@ -16,6 +16,7 @@
 // usePermissionCache.ts delegates here (this is the leaf module → no import cycle).
 import { meControllerPermissions } from '@nova-id/api-client'
 import type { PermissionsResponseDto } from '@nova-id/api-client'
+import { logger, errMessage } from '../utils/logger'
 
 // Module-level memoized promise for the raw /me/permissions response.
 let _cachedPermsPromise: Promise<PermissionsResponseDto> | null = null
@@ -45,7 +46,7 @@ export async function canAccessAdmin(_userId?: string): Promise<boolean> {
     const perms = await fetchMyPermissions()
     return perms.canAccessAdmin === true
   } catch (error) {
-    console.error('canAccessAdmin failed:', error)
+    logger.error('canAccessAdmin failed:', errMessage(error))
     return false
   }
 }
@@ -56,7 +57,7 @@ export async function canManagePermissions(_userId?: string): Promise<boolean> {
     const perms = await fetchMyPermissions()
     return perms.canManagePermissions === true
   } catch (error) {
-    console.error('canManagePermissions failed:', error)
+    logger.error('canManagePermissions failed:', errMessage(error))
     return false
   }
 }
@@ -89,7 +90,7 @@ export async function getAllUserPermissionFlags(_userId?: string, forceRefresh =
       canAccessAdmin: perms.canAccessAdmin === true,
     }
   } catch (error) {
-    console.error('Error getting user permission flags:', error)
+    logger.error('Error getting user permission flags:', errMessage(error))
     return {
       canViewUsers: false,
       canAddUsers: false,

--- a/frontend-admin/src/views/Home.vue
+++ b/frontend-admin/src/views/Home.vue
@@ -106,6 +106,7 @@ import { useRouter } from 'vue-router'
 import NovaLogoIcon from '../components/NovaLogoIcon.vue'
 import { checkSession, logout } from '../composables/useAuth'
 import { canAccessAdmin } from '../composables/usePermissions'
+import { logger, errMessage } from '../utils/logger'
 
 const router = useRouter()
 const loading = ref(false)
@@ -120,7 +121,7 @@ const startLogin = async () => {
     try {
       session = await checkSession()
     } catch (e) {
-      if ((e as { response?: { status?: number } })?.response?.status !== 401) console.error('startLogin:', e)
+      if ((e as { response?: { status?: number } })?.response?.status !== 401) logger.error('startLogin:', errMessage(e))
     }
     if (session?.identity?.id) {
       await checkAccess()
@@ -129,7 +130,7 @@ const startLogin = async () => {
     const returnTo = window.location.origin + '/dashboard'
     window.location.href = `${authUiUrl()}/auth/login?return_to=${encodeURIComponent(returnTo)}`
   } catch (error) {
-    console.error('startLogin:', error)
+    logger.error('startLogin:', errMessage(error))
     const returnTo = window.location.origin + '/dashboard'
     window.location.href = `${authUiUrl()}/auth/login?return_to=${encodeURIComponent(returnTo)}`
   } finally {

--- a/frontend-admin/src/views/PermissionsManagement.vue
+++ b/frontend-admin/src/views/PermissionsManagement.vue
@@ -181,6 +181,7 @@ import {
   deleteClient
 } from '../composables/useHydra'
 import type { OAuthClient } from '../composables/useHydra'
+import { logger, errMessage } from '../utils/logger'
 
 const router = useRouter()
 const activeTab = ref<'permissions' | 'test' | 'oauth'>('permissions')
@@ -212,7 +213,7 @@ onMounted(async () => {
       return
     }
   } catch (error) {
-    console.error('Error checking permission', { status: (error as { response?: { status?: number } })?.response?.status })
+    logger.error('Error checking permission', String((error as { response?: { status?: number } })?.response?.status ?? ''))
     router.push('/dashboard')
     return
   }
@@ -226,7 +227,7 @@ const loadOAuthClients = async () => {
   try {
     oauthClients.value = await listClients()
   } catch (err) {
-    console.error('Error loading OAuth clients:', err)
+    logger.error('Error loading OAuth clients:', errMessage(err))
     error.value = (err as Error).message || 'Failed to load OAuth clients'
   } finally {
     loadingClients.value = false

--- a/frontend-admin/src/views/UsersManagement.vue
+++ b/frontend-admin/src/views/UsersManagement.vue
@@ -587,6 +587,7 @@ import {
 import type { UserResponseDto, CreateUserDto, UpdateUserDto } from '@nova-id/api-client'
 import { checkSession, markEmailAsVerified } from '../composables/useAuth'
 import { getRoleBadgeClass } from '../utils/roleColors'
+import { logger, errMessage } from '../utils/logger'
 import type { Identity } from '@ory/client'
 
 const router = useRouter()
@@ -699,7 +700,7 @@ onMounted(async () => {
       return
     }
   } catch (err) {
-    console.error('Error checking permission', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error checking permission', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     router.push('/dashboard')
     return
   } finally {
@@ -854,7 +855,7 @@ const createUserAction = async () => {
     setTimeout(() => { success.value = null }, 3000)
   } catch (err) {
     // Do not log err directly — may carry BFF body with PHI.
-    console.error('Error creating user', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error creating user', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     error.value = 'Failed to create user. Please try again.'
   } finally {
     creatingUser.value = false
@@ -882,7 +883,7 @@ const deleteUserAction = async () => {
     await invalidateUsers()
     setTimeout(() => { success.value = null }, 3000)
   } catch (err) {
-    console.error('Error deleting user', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error deleting user', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     error.value = 'Failed to delete user. Please try again.'
   } finally {
     deleting.value = false
@@ -915,7 +916,7 @@ const sendRecoveryPassword = async (user: UserResponseDto) => {
       copiedCode: false
     }
   } catch (err) {
-    console.error('Error creating recovery link', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error creating recovery link', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     error.value = 'Failed to create recovery link. Please try again.'
   } finally {
     sendingRecovery.value = null
@@ -937,7 +938,7 @@ const copyToClipboard = async (text: string, type: 'url' | 'code') => {
       }, 2000)
     }
   } catch (err) {
-    console.error('Failed to copy to clipboard:', err)
+    logger.error('Failed to copy to clipboard:', errMessage(err))
     // Fallback for older browsers
     const textArea = document.createElement('textarea')
     textArea.value = text
@@ -963,7 +964,7 @@ const copyToClipboard = async (text: string, type: 'url' | 'code') => {
         }, 2000)
       }
     } catch (fallbackErr) {
-      console.error('Fallback copy failed:', fallbackErr)
+      logger.error('Fallback copy failed:', errMessage(fallbackErr))
     }
     document.body.removeChild(textArea)
   }
@@ -1013,7 +1014,7 @@ const saveUser = async () => {
     await invalidateUsers()
     setTimeout(() => { success.value = null }, 3000)
   } catch (err) {
-    console.error('Error updating user', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error updating user', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     error.value = 'Failed to update user. Please try again.'
   } finally {
     saving.value = false
@@ -1031,7 +1032,7 @@ const verifyEmail = async (user: UserResponseDto) => {
     const result = await markEmailAsVerified(user.email)
     success.value = `Verification email sent to ${result?.userEmail || user.email}.`
   } catch (err) {
-    console.error('Error sending verification email', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error sending verification email', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     error.value = 'Failed to send verification email. Please try again.'
   } finally {
     verifyingEmail.value = null
@@ -1047,7 +1048,7 @@ const viewPermissions = async (user: UserResponseDto) => {
     const { getCachedUserPermissions } = await import('../composables/usePermissionCache')
     userPermissionsList.value = await getCachedUserPermissions(user.id)
   } catch (err) {
-    console.error('Error loading user permissions', { status: (err as { response?: { status?: number } })?.response?.status })
+    logger.error('Error loading user permissions', String((err as { response?: { status?: number } })?.response?.status ?? ''))
     userPermissionsList.value = []
   } finally {
     loadingUserPermissions.value = false

--- a/frontend-app/src/utils/logger.ts
+++ b/frontend-app/src/utils/logger.ts
@@ -1,11 +1,10 @@
 /**
  * App logger: in production only warn/error are emitted, and ONLY with string
  * arguments. In development all levels pass through. Use this instead of
- * console.* so prod builds never leak raw error objects (which can carry OAuth
- * client secrets, Kratos CSRF tokens, or user PII).
+ * console.* so prod builds never leak raw error objects.
  *
  * Safe usage pattern:
- *   logger.error('doSomething failed', errMessage(e))
+ *   logger.error('loadLogs failed', errMessage(e))
  *   logger.warn('unexpected status', String(status))
  */
 const isProd = import.meta.env.PROD
@@ -22,30 +21,30 @@ export function errMessage(e: unknown): string {
 
 export const logger = {
   debug (...args: unknown[]) {
-    if (!isProd) console.debug('[admin]', ...args)
+    if (!isProd) console.debug('[app]', ...args)
   },
   log (...args: unknown[]) {
-    if (!isProd) console.log('[admin]', ...args)
+    if (!isProd) console.log('[app]', ...args)
   },
   info (...args: unknown[]) {
-    if (!isProd) console.info('[admin]', ...args)
+    if (!isProd) console.info('[app]', ...args)
   },
   warn (...args: unknown[]) {
     // In prod, only accept strings to avoid leaking objects
     if (isProd) {
       const safeArgs = args.filter(a => typeof a === 'string' || typeof a === 'number')
-      if (safeArgs.length) console.warn('[admin]', ...safeArgs)
+      if (safeArgs.length) console.warn('[app]', ...safeArgs)
     } else {
-      console.warn('[admin]', ...args)
+      console.warn('[app]', ...args)
     }
   },
   error (...args: unknown[]) {
     // In prod, only accept strings to avoid leaking objects
     if (isProd) {
       const safeArgs = args.filter(a => typeof a === 'string' || typeof a === 'number')
-      if (safeArgs.length) console.error('[admin]', ...safeArgs)
+      if (safeArgs.length) console.error('[app]', ...safeArgs)
     } else {
-      console.error('[admin]', ...args)
+      console.error('[app]', ...args)
     }
   }
 }

--- a/frontend-app/src/views/Logs.vue
+++ b/frontend-app/src/views/Logs.vue
@@ -264,6 +264,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { getApiTestBaseUrl } from '../composables/useApiTest'
 import type { LogEntry, LogStats, MeResponse, DemoUser } from '../types'
+import { logger, errMessage } from '../utils/logger'
 
 const router = useRouter()
 const allowed = ref(false)
@@ -394,7 +395,7 @@ async function loadLogs() {
   } catch (err) {
     logs.value = []
     stats.value = {}
-    console.error('Failed to load logs:', err)
+    logger.error('Failed to load logs:', errMessage(err))
   } finally {
     loading.value = false
   }

--- a/frontend-auth/src/utils/logger.ts
+++ b/frontend-auth/src/utils/logger.ts
@@ -1,11 +1,11 @@
 /**
  * App logger: in production only warn/error are emitted, and ONLY with string
  * arguments. In development all levels pass through. Use this instead of
- * console.* so prod builds never leak raw error objects (which can carry OAuth
- * client secrets, Kratos CSRF tokens, or user PII).
+ * console.* so prod builds never leak raw error objects (which can carry Kratos
+ * flow bodies, CSRF tokens, or user PII).
  *
  * Safe usage pattern:
- *   logger.error('doSomething failed', errMessage(e))
+ *   logger.error('loadLoginFlow failed', errMessage(e))
  *   logger.warn('unexpected status', String(status))
  */
 const isProd = import.meta.env.PROD
@@ -22,30 +22,30 @@ export function errMessage(e: unknown): string {
 
 export const logger = {
   debug (...args: unknown[]) {
-    if (!isProd) console.debug('[admin]', ...args)
+    if (!isProd) console.debug('[auth]', ...args)
   },
   log (...args: unknown[]) {
-    if (!isProd) console.log('[admin]', ...args)
+    if (!isProd) console.log('[auth]', ...args)
   },
   info (...args: unknown[]) {
-    if (!isProd) console.info('[admin]', ...args)
+    if (!isProd) console.info('[auth]', ...args)
   },
   warn (...args: unknown[]) {
     // In prod, only accept strings to avoid leaking objects
     if (isProd) {
       const safeArgs = args.filter(a => typeof a === 'string' || typeof a === 'number')
-      if (safeArgs.length) console.warn('[admin]', ...safeArgs)
+      if (safeArgs.length) console.warn('[auth]', ...safeArgs)
     } else {
-      console.warn('[admin]', ...args)
+      console.warn('[auth]', ...args)
     }
   },
   error (...args: unknown[]) {
     // In prod, only accept strings to avoid leaking objects
     if (isProd) {
       const safeArgs = args.filter(a => typeof a === 'string' || typeof a === 'number')
-      if (safeArgs.length) console.error('[admin]', ...safeArgs)
+      if (safeArgs.length) console.error('[auth]', ...safeArgs)
     } else {
-      console.error('[admin]', ...args)
+      console.error('[auth]', ...args)
     }
   }
 }

--- a/frontend-auth/src/views/Consent.vue
+++ b/frontend-auth/src/views/Consent.vue
@@ -73,6 +73,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { acceptHydraConsent } from '@nova-id/api-client'
+import { logger, errMessage } from '../utils/logger'
 
 interface ConsentInfo {
   skip?: boolean
@@ -138,7 +139,7 @@ onMounted(async () => {
     loading.value = false
   } catch (err) {
     error.value = (err as Error).message || 'Failed to load consent information'
-    console.error('Error loading consent info:', err)
+    logger.error('Error loading consent info:', errMessage(err))
     loading.value = false
   }
 })
@@ -169,7 +170,7 @@ const acceptConsent = async () => {
   } catch (err) {
     const e = err as { response?: { data?: { message?: string } }; message?: string }
     error.value = e.response?.data?.message || e.message || 'Failed to accept consent'
-    console.error('Error accepting consent:', err)
+    logger.error('Error accepting consent:', errMessage(err))
     processing.value = false
   }
 }
@@ -207,7 +208,7 @@ const rejectConsent = async () => {
     }
   } catch (err) {
     error.value = (err as Error).message || 'Failed to reject consent'
-    console.error('Error rejecting consent:', err)
+    logger.error('Error rejecting consent:', errMessage(err))
     processing.value = false
   }
 }

--- a/frontend-auth/src/views/Login.vue
+++ b/frontend-auth/src/views/Login.vue
@@ -238,6 +238,7 @@ import NovaLogoIcon from '../components/NovaLogoIcon.vue'
 import { createLoginFlow, getLoginFlow, updateLoginFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
+import { logger, errMessage } from '../utils/logger'
 
 const refreshAuth = inject<(() => Promise<void>) | null>('refreshAuth', null)
 import {
@@ -289,7 +290,7 @@ onMounted(async () => {
       flow.value = await createLoginFlow(returnUrl)
     }
   } catch (error) {
-    console.error('Error loading login flow:', error)
+    logger.error('Error loading login flow:', errMessage(error))
     router.push('/error')
   }
 })
@@ -509,7 +510,7 @@ const handleSubmit = async (event: Event) => {
       if (errId) {
         router.push({ path: '/error', query: { id: errId, ...(route.query.return_to && { return_to: route.query.return_to }) } })
       } else {
-        console.error('Login error:', error)
+        logger.error('Login error:', errMessage(error))
         router.push('/error')
       }
     }

--- a/frontend-auth/src/views/Recovery.vue
+++ b/frontend-auth/src/views/Recovery.vue
@@ -223,6 +223,7 @@ import NovaLogoIcon from '../components/NovaLogoIcon.vue'
 import { createRecoveryFlow, getRecoveryFlow, updateRecoveryFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
+import { logger, errMessage } from '../utils/logger'
 import {
   getNodeValue,
   getNodeName,
@@ -316,7 +317,7 @@ onMounted(async () => {
       flow.value = await createRecoveryFlow(returnTo.value || null)
     }
   } catch (error) {
-    console.error('Error loading recovery flow:', error)
+    logger.error('Error loading recovery flow:', errMessage(error))
     router.push('/error')
   }
 })
@@ -400,11 +401,11 @@ async function handleResendCode(resendNode: UiNodeLike) {
           flow.value = await getRecoveryFlow(useFlowId)
           router.replace({ path: '/recovery', query: { ...route.query, flow: useFlowId } })
         } catch (e2) {
-          console.error('Failed to load new flow:', e2)
+          logger.error('Failed to load new flow:', errMessage(e2))
         }
       }
     } else {
-      console.error('Resend code failed:', err)
+      logger.error('Resend code failed:', errMessage(err))
     }
   } finally {
     loading.value = false
@@ -522,11 +523,11 @@ const handleSubmit = async (event: Event) => {
           }
           router.replace({ path: '/recovery', query: { ...route.query, flow: useFlowId } })
         } catch (e) {
-          console.error('Failed to load new flow:', e)
+          logger.error('Failed to load new flow:', errMessage(e))
         }
       }
     } else {
-      console.error('Recovery error:', error)
+      logger.error('Recovery error:', errMessage(error))
       router.push('/error')
     }
   } finally {

--- a/frontend-auth/src/views/Registration.vue
+++ b/frontend-auth/src/views/Registration.vue
@@ -223,6 +223,7 @@ import NovaLogoIcon from '../components/NovaLogoIcon.vue'
 import { createRegistrationFlow, getRegistrationFlow, updateRegistrationFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
+import { logger, errMessage } from '../utils/logger'
 import {
   getNodeValue,
   getNodeName,
@@ -355,7 +356,7 @@ onMounted(async () => {
       })
     }
   } catch (error) {
-    console.error('Error loading registration flow:', error)
+    logger.error('Error loading registration flow:', errMessage(error))
     router.push('/error')
   }
 })
@@ -485,7 +486,7 @@ const handleSubmit = async (event: Event) => {
       // Update flow with error response (includes new flow state)
       flow.value = e.response.data ?? null
     } else {
-      console.error('Registration error:', error)
+      logger.error('Registration error:', errMessage(error))
       router.push('/error')
     }
   } finally {

--- a/frontend-auth/src/views/Settings.vue
+++ b/frontend-auth/src/views/Settings.vue
@@ -207,6 +207,7 @@ import type { UpdateSettingsFlowBody } from '@ory/client'
 import { getSettingsFlow, updateSettingsFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
+import { logger, errMessage } from '../utils/logger'
 import {
   getNodeValue,
   getNodeName,
@@ -341,7 +342,7 @@ onMounted(async () => {
       router.push('/error')
     }
   } catch (error) {
-    console.error('Error loading settings flow:', error)
+    logger.error('Error loading settings flow:', errMessage(error))
     router.push('/error')
   }
 })
@@ -509,7 +510,7 @@ const handleSubmit = async (event: Event) => {
     if (e.response?.status === 400) {
       flow.value = e.response.data ?? null
     } else {
-      console.error('Settings error:', error)
+      logger.error('Settings error:', errMessage(error))
       router.push('/error')
     }
   } finally {

--- a/frontend-auth/src/views/Verification.vue
+++ b/frontend-auth/src/views/Verification.vue
@@ -264,6 +264,7 @@ import NovaLogoIcon from '../components/NovaLogoIcon.vue'
 import { createBrowserVerificationFlow, getVerificationFlow, updateVerificationFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
+import { logger, errMessage } from '../utils/logger'
 import {
   getNodeValue,
   getNodeName,
@@ -407,7 +408,7 @@ onMounted(async () => {
       }
     }
   } catch (error) {
-    console.error('Error loading verification flow:', error)
+    logger.error('Error loading verification flow:', errMessage(error))
     router.push('/error')
   }
 })
@@ -491,11 +492,11 @@ async function handleResendCode(resendNode: UiNodeLike) {
           flow.value = await getVerificationFlow(useFlowId)
           router.replace({ path: '/verification', query: { ...route.query, flow: useFlowId } })
         } catch (e2) {
-          console.error('Failed to load new flow:', e2)
+          logger.error('Failed to load new flow:', errMessage(e2))
         }
       }
     } else {
-      console.error('Resend verification email failed:', err)
+      logger.error('Resend verification email failed:', errMessage(err))
     }
   } finally {
     loading.value = false
@@ -583,11 +584,11 @@ const handleSubmit = async (event: Event) => {
           const q = { ...route.query, flow: useFlowId }
           router.replace({ path: '/verification', query: q })
         } catch (e) {
-          console.error('Failed to load new flow:', e)
+          logger.error('Failed to load new flow:', errMessage(e))
         }
       }
     } else {
-      console.error('Verification error:', error)
+      logger.error('Verification error:', errMessage(error))
       router.push('/error')
     }
   } finally {


### PR DESCRIPTION
## A2 hardening — PR 4 of 4 (phase 7)

- Each SPA gets a tiny `src/utils/logger.ts`: `debug/log/info` are dev-only (suppressed in prod); `warn/error` emit in prod but filter args to primitives (raw objects dropped). Exports `errMessage(e: unknown)` — a safe extractor that returns only the message string and never reaches into `error.response.data` or serializes a body.
- All raw `console.*` across the 3 SPAs (28+19+1) replaced with logger calls. The secret/PHI-leaking sites — `useHydra.ts` (OAuth client errors → possible client_secret), `UsersManagement.vue`, `Home.vue`, `Login.vue`, and the Kratos flow views (CSRF/identity bodies) — now log a context string + `errMessage`/status only, never the raw error object.
- Two-layer guarantee: callers pass primitives AND the logger drops non-primitives in prod, so a future careless caller can't reintroduce a leak.

Reviewed (opus): zero blockers/warnings/nits. 0 `console.*` remain outside the logger utils; all 3 SPAs `vue-tsc --noEmit` clean + build green; pure logging refactor, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)