### PR TITLE
fix(bff): audit privilege events, harden access log, type consent path

### DIFF
--- a/api/src/app.service.spec.ts
+++ b/api/src/app.service.spec.ts
@@ -12,13 +12,23 @@ function makeHydra() {
 function makeKeto() {
   return { checkApp: jest.fn() };
 }
-const user = { userId: 'u1', email: 'a@b.c', full_name: 'A B', role: 'platform_admin' };
+function makeAudit() {
+  return { record: jest.fn().mockResolvedValue(undefined) };
+}
+const user = {
+  userId: 'u1',
+  email: 'a@b.c',
+  full_name: 'A B',
+  role: 'platform_admin',
+  authMethod: 'jwt' as const,
+  jwtClaims: {},
+};
 
 describe('AppService.acceptHydraLogin', () => {
   it('honors skip=true: accepts with subject only, no context claims', async () => {
     const hydra = makeHydra();
     hydra.getLoginRequest.mockResolvedValue({ skip: true, subject: 'u1' });
-    const svc = new AppService(hydra as any, makeKeto() as any);
+    const svc = new AppService(hydra as any, makeKeto() as any, makeAudit() as any);
 
     await svc.acceptHydraLogin(user, 'chal');
 
@@ -32,7 +42,7 @@ describe('AppService.acceptHydraLogin', () => {
   it('skip=false: puts claims on context, never on session', async () => {
     const hydra = makeHydra();
     hydra.getLoginRequest.mockResolvedValue({ skip: false });
-    const svc = new AppService(hydra as any, makeKeto() as any);
+    const svc = new AppService(hydra as any, makeKeto() as any, makeAudit() as any);
 
     await svc.acceptHydraLogin(user, 'chal');
 
@@ -54,7 +64,7 @@ describe('AppService.acceptHydraConsent', () => {
     });
     const keto = makeKeto();
     keto.checkApp.mockResolvedValue(false);
-    const svc = new AppService(hydra as any, keto as any);
+    const svc = new AppService(hydra as any, keto as any, makeAudit() as any);
 
     const out = await svc.acceptHydraConsent(user, { consent_challenge: 'cc', grant_scope: ['openid'] });
 
@@ -62,6 +72,31 @@ describe('AppService.acceptHydraConsent', () => {
     expect(hydra.acceptConsent).not.toHaveBeenCalled();
     expect(hydra.rejectConsent).toHaveBeenCalledWith('cc', expect.objectContaining({ error: 'access_denied' }));
     expect(out.redirect_to).toBe('http://denied');
+  });
+
+  it('consent.deny: emits audit record with action=consent.deny, actorId, appId, targetType=app', async () => {
+    const hydra = makeHydra();
+    hydra.getConsentRequest.mockResolvedValue({
+      client: { client_id: 'nova-id-test-app' },
+      requested_access_token_audience: ['aud1'],
+      requested_scope: ['openid'],
+    });
+    const keto = makeKeto();
+    keto.checkApp.mockResolvedValue(false);
+    const audit = makeAudit();
+    const svc = new AppService(hydra as any, keto as any, audit as any);
+
+    await svc.acceptHydraConsent(user, { consent_challenge: 'cc', grant_scope: ['openid'] });
+
+    expect(audit.record).toHaveBeenCalledTimes(1);
+    expect(audit.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'u1',
+        action: 'consent.deny',
+        appId: 'nova-id-test-app',
+        targetType: 'app',
+      }),
+    );
   });
 
   it('members: accepts with trusted audience, role on id_token AND access_token, app:member scope, no appRole', async () => {
@@ -73,7 +108,7 @@ describe('AppService.acceptHydraConsent', () => {
     });
     const keto = makeKeto();
     keto.checkApp.mockResolvedValue(true);
-    const svc = new AppService(hydra as any, keto as any);
+    const svc = new AppService(hydra as any, keto as any, makeAudit() as any);
 
     await svc.acceptHydraConsent(user, { consent_challenge: 'cc', grant_scope: ['openid', 'profile'] });
 
@@ -101,7 +136,7 @@ describe('AppService.acceptHydraConsent', () => {
     });
     const keto = makeKeto();
     keto.checkApp.mockResolvedValue(true);
-    const svc = new AppService(hydra as any, keto as any);
+    const svc = new AppService(hydra as any, keto as any, makeAudit() as any);
 
     // Tampered body includes a scope the client never requested
     await svc.acceptHydraConsent(user, {
@@ -127,7 +162,7 @@ describe('AppService.acceptHydraConsent', () => {
     });
     const keto = makeKeto();
     keto.checkApp.mockResolvedValue(true);
-    const svc = new AppService(hydra as any, keto as any);
+    const svc = new AppService(hydra as any, keto as any, makeAudit() as any);
 
     await svc.acceptHydraConsent(user, {
       consent_challenge: 'cc',

--- a/api/src/app.service.ts
+++ b/api/src/app.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { HydraService } from './ory/hydra.service';
 import { KetoService } from './ory/keto.service';
+import { AuditService } from './audit/audit.service';
+import { AuthenticatedUser } from './common/types/authenticated-user';
+import { AcceptHydraConsentDto } from './dto/accept-hydra-consent.dto';
 
 @Injectable()
 export class AppService {
@@ -9,6 +12,7 @@ export class AppService {
   constructor(
     private readonly hydra: HydraService,
     private readonly keto: KetoService,
+    private readonly audit: AuditService,
   ) {}
 
   getPublicData() {
@@ -23,7 +27,7 @@ export class AppService {
     };
   }
 
-  async acceptHydraLogin(user: any, loginChallenge: string) {
+  async acceptHydraLogin(user: AuthenticatedUser, loginChallenge: string) {
     try {
       this.logger.log(`Accepting Hydra login for user ${user.userId}`);
       const loginRequest = await this.hydra.getLoginRequest(loginChallenge);
@@ -54,7 +58,7 @@ export class AppService {
     }
   }
 
-  async acceptHydraConsent(user: any, body: any) {
+  async acceptHydraConsent(user: AuthenticatedUser, body: AcceptHydraConsentDto) {
     try {
       const consentChallenge = body.consent_challenge;
       this.logger.log(`Consent for user ${user.userId} (challenge ${consentChallenge})`);
@@ -66,6 +70,12 @@ export class AppService {
       const isMember = clientId ? await this.keto.checkApp(user.userId, clientId) : false;
       if (!isMember) {
         this.logger.warn(`Consent DENIED: ${user.userId} is not a member of app ${clientId}`);
+        await this.audit.record({
+          actorId: user.userId,
+          action: 'consent.deny',
+          appId: clientId ?? null,
+          targetType: 'app',
+        });
         return await this.hydra.rejectConsent(consentChallenge, {
           error: 'access_denied',
           error_description: 'You are not authorized to access this application.',

--- a/api/src/demo/demo-seed.service.ts
+++ b/api/src/demo/demo-seed.service.ts
@@ -34,14 +34,10 @@ export class DemoSeedService implements OnApplicationBootstrap {
 
     this.logger.log('[demo-seed] Starting SQLite app_admin seed...');
 
+    // Fetch all identities with pagination (per_page=200) and a 10 s timeout.
     let identities: Array<{ id: string; traits?: { email?: string } }>;
     try {
-      const res = await fetch(`${kratosAdminUrl}/admin/identities`);
-      if (!res.ok) {
-        this.logger.warn(`[demo-seed] Kratos admin identities returned HTTP ${res.status} — skipping seed.`);
-        return;
-      }
-      identities = await res.json();
+      identities = await this.fetchAllIdentities(kratosAdminUrl);
     } catch (err) {
       this.logger.warn(`[demo-seed] Could not reach Kratos admin API: ${(err as Error).message} — skipping seed.`);
       return;
@@ -74,5 +70,60 @@ export class DemoSeedService implements OnApplicationBootstrap {
     }
 
     this.logger.log(`[demo-seed] Done: ${seeded} seeded, ${skipped} already set.`);
+  }
+
+  /**
+   * Fetch all Kratos identities with cursor pagination and a per-request timeout.
+   *
+   * Kratos Admin API supports `?page_size=<n>&page_token=<cursor>`.  We loop
+   * until the `Link` header contains no `rel="next"` URL, collecting all pages.
+   * Each page request times out after FETCH_TIMEOUT_MS to prevent a hanging seed.
+   */
+  private async fetchAllIdentities(
+    kratosAdminUrl: string,
+  ): Promise<Array<{ id: string; traits?: { email?: string } }>> {
+    const FETCH_TIMEOUT_MS = 10_000;
+    const PER_PAGE = 200;
+
+    const all: Array<{ id: string; traits?: { email?: string } }> = [];
+    let pageToken: string | null = null;
+
+    for (;;) {
+      const url = new URL(`${kratosAdminUrl}/admin/identities`);
+      url.searchParams.set('page_size', String(PER_PAGE));
+      if (pageToken) {
+        url.searchParams.set('page_token', pageToken);
+      }
+
+      const res = await fetch(url.toString(), {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+
+      if (!res.ok) {
+        this.logger.warn(
+          `[demo-seed] Kratos admin identities returned HTTP ${res.status} — skipping seed.`,
+        );
+        return all;
+      }
+
+      const page = (await res.json()) as Array<{ id: string; traits?: { email?: string } }>;
+      all.push(...page);
+
+      // Kratos signals "more pages" via a `Link: <url>; rel="next"` header.
+      const linkHeader = res.headers.get('link') ?? '';
+      const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+      if (!nextMatch || page.length === 0) {
+        break; // Last page.
+      }
+
+      // Extract page_token from the next URL.
+      const nextUrl = new URL(nextMatch[1]);
+      pageToken = nextUrl.searchParams.get('page_token');
+      if (!pageToken) {
+        break;
+      }
+    }
+
+    return all;
   }
 }

--- a/api/src/demo/logging.interceptor.spec.ts
+++ b/api/src/demo/logging.interceptor.spec.ts
@@ -1,0 +1,121 @@
+import { LoggingInterceptor } from './logging.interceptor';
+import { of, throwError } from 'rxjs';
+
+/**
+ * LoggingInterceptor identity-extraction spec (Task 2 — M-2).
+ *
+ * Verifies that spoofable X-User-* headers are NEVER used; when
+ * request.user is absent all identity fields fall back to 'anonymous'.
+ */
+
+function makeReflector(shouldLog: boolean) {
+  return { getAllAndOverride: jest.fn().mockReturnValue(shouldLog) } as any;
+}
+
+function makeLogsService() {
+  return { logAccess: jest.fn() } as any;
+}
+
+function makeContext(request: object): any {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  };
+}
+
+describe('LoggingInterceptor — identity extraction (M-2)', () => {
+  it('uses request.user fields when present', async () => {
+    const logsService = makeLogsService();
+    const interceptor = new LoggingInterceptor(makeReflector(true), logsService);
+
+    const req = {
+      method: 'GET',
+      url: '/test',
+      headers: {},
+      user: { userId: 'real-uid', email: 'real@example.com', role: 'app_user' },
+    };
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(makeContext(req), { handle: () => of({ ok: true }) }).subscribe({
+        complete: resolve,
+      });
+    });
+
+    expect(logsService.logAccess).toHaveBeenCalledTimes(1);
+    const entry = logsService.logAccess.mock.calls[0][0];
+    expect(entry.user.id).toBe('real-uid');
+    expect(entry.user.email).toBe('real@example.com');
+    expect(entry.user.role).toBe('app_user');
+  });
+
+  it('falls back to "anonymous" for ALL identity fields when request.user is absent', async () => {
+    const logsService = makeLogsService();
+    const interceptor = new LoggingInterceptor(makeReflector(true), logsService);
+
+    const req = {
+      method: 'GET',
+      url: '/public',
+      headers: {
+        // Spoofed headers — must be IGNORED
+        'x-user-id': 'spoofed-uid',
+        'x-user-email': 'spoofed@evil.com',
+        'x-user-role': 'platform_admin',
+      },
+      // No user object
+    };
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(makeContext(req), { handle: () => of({}) }).subscribe({
+        complete: resolve,
+      });
+    });
+
+    const entry = logsService.logAccess.mock.calls[0][0];
+    expect(entry.user.id).toBe('anonymous');
+    expect(entry.user.email).toBe('anonymous');
+    expect(entry.user.role).toBe('anonymous');
+    // Confirm the spoofed values were NOT used
+    expect(entry.user.id).not.toBe('spoofed-uid');
+    expect(entry.user.role).not.toBe('platform_admin');
+    expect(entry.user.role).not.toBe('platform_user');
+  });
+
+  it('logs "anonymous" on error path when request.user is absent', async () => {
+    const logsService = makeLogsService();
+    const interceptor = new LoggingInterceptor(makeReflector(true), logsService);
+
+    const req = {
+      method: 'POST',
+      url: '/fail',
+      headers: { 'x-user-id': 'evil', 'x-user-role': 'platform_admin' },
+    };
+
+    await new Promise<void>((resolve) => {
+      interceptor
+        .intercept(makeContext(req), {
+          handle: () => throwError(() => ({ message: 'boom', status: 500 })),
+        })
+        .subscribe({ error: () => resolve() });
+    });
+
+    const entry = logsService.logAccess.mock.calls[0][0];
+    expect(entry.user.id).toBe('anonymous');
+    expect(entry.user.role).toBe('anonymous');
+  });
+
+  it('skips logging when @LogAccess is not set', async () => {
+    const logsService = makeLogsService();
+    const interceptor = new LoggingInterceptor(makeReflector(false), logsService);
+
+    const req = { method: 'GET', url: '/no-log', headers: {} };
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(makeContext(req), { handle: () => of({}) }).subscribe({
+        complete: resolve,
+      });
+    });
+
+    expect(logsService.logAccess).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/demo/logging.interceptor.ts
+++ b/api/src/demo/logging.interceptor.ts
@@ -34,9 +34,11 @@ export class LoggingInterceptor implements NestInterceptor {
 
     const startTime = Date.now();
     const frontendSource = this.extractFrontendSource(headers, request);
-    const userId = request.user?.userId || headers['x-user-id'] || 'anonymous';
-    const userEmail = request.user?.email || headers['x-user-email'] || 'anonymous';
-    const userRole = request.user?.role || headers['x-user-role'] || 'platform_user';
+    // Never fall back to X-User-* headers — they are spoofable (M-2).
+    // When request.user is absent (unauthenticated / Public decorator), use 'anonymous'.
+    const userId = request.user?.userId ?? 'anonymous';
+    const userEmail = request.user?.email ?? 'anonymous';
+    const userRole = request.user?.role ?? 'anonymous';
     const authMethod = request.user?.authMethod || 'session';
     const clientId = request.user?.clientId || null;
 

--- a/api/src/demo/logs/logs.controller.spec.ts
+++ b/api/src/demo/logs/logs.controller.spec.ts
@@ -1,114 +1,79 @@
-import { ForbiddenException } from '@nestjs/common';
 import { LogsController } from './logs.controller';
 
 /**
- * Logs controller access-gate spec (ADR-0002 / ADR-0003, strict layering).
+ * Logs controller spec (ADR-0002 / ADR-0003, strict layering).
  *
- * The SOLE gate for /logs is app role app_admin read from SQLite.
- * platform_admin is an infra-layer role and MUST NOT grant log access —
- * the bypass was removed in this commit.
+ * Access gate is now enforced by AppAdminGuard (class-level @UseGuards),
+ * which is separately exercised in app-admin.guard.spec.ts.  These tests
+ * cover the controller's routing and delegation logic assuming the guard
+ * has already admitted the caller.
+ *
+ * Authorization behaviour:
+ *   - The SOLE gate is app role app_admin from SQLite (ADR-0002).
+ *   - platform_admin does NOT grant access (ADR-0003, strict layering).
+ * Both rules are enforced inside AppAdminGuard — see its spec for the
+ * full coverage matrix.
  */
 
-function makeController(appRoleFromDb: 'app_admin' | 'app_user') {
+function makeController() {
   const logsService = {
-    getAccessLogs: jest.fn().mockReturnValue([]),
-    getAccessLogsFiltered: jest.fn().mockReturnValue([]),
-    getAccessStats: jest.fn().mockReturnValue({}),
-    getAccessLogsByFrontend: jest.fn().mockReturnValue([]),
-    getAccessLogsByUser: jest.fn().mockReturnValue([]),
+    getAccessLogs: jest.fn().mockReturnValue([{ url: '/test' }]),
+    getAccessLogsFiltered: jest.fn().mockReturnValue([{ url: '/filtered' }]),
+    getAccessStats: jest.fn().mockReturnValue({ totalRequests: 42 }),
+    getAccessLogsByFrontend: jest.fn().mockReturnValue([{ url: '/fe' }]),
+    getAccessLogsByUser: jest.fn().mockReturnValue([{ url: '/user' }]),
   } as any;
 
-  const rolesService = {
-    getAppRole: jest.fn().mockResolvedValue(appRoleFromDb),
-  } as any;
-
-  return { controller: new LogsController(logsService, rolesService), rolesService, logsService };
+  return { controller: new LogsController(logsService), logsService };
 }
 
-function reqWith(user: object) {
-  return { user };
-}
-
-describe('LogsController access gate (ADR-0002 / ADR-0003)', () => {
+describe('LogsController routing (access gate = AppAdminGuard)', () => {
   describe('getLogs', () => {
-    it('allows a user whose SQLite app role is app_admin', async () => {
-      const { controller } = makeController('app_admin');
-      const result = await controller.getLogs(reqWith({ userId: 'u-admin' }));
-      expect(result).toEqual([]);
+    it('delegates to getAccessLogs when no filters are supplied', async () => {
+      const { controller, logsService } = makeController();
+      const result = await controller.getLogs();
+      expect(logsService.getAccessLogs).toHaveBeenCalledWith(100);
+      expect(result).toEqual([{ url: '/test' }]);
     });
 
-    it('denies a user whose SQLite app role is app_user', async () => {
-      const { controller } = makeController('app_user');
-      await expect(
-        controller.getLogs(reqWith({ userId: 'u-user' })),
-      ).rejects.toBeInstanceOf(ForbiddenException);
+    it('delegates to getAccessLogsFiltered when a filter is provided', async () => {
+      const { controller, logsService } = makeController();
+      const result = await controller.getLogs(undefined, undefined, 'GET');
+      expect(logsService.getAccessLogsFiltered).toHaveBeenCalledWith(
+        100,
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toEqual([{ url: '/filtered' }]);
     });
 
-    it('denies a platform_admin whose SQLite app role is app_user (bypass removed, ADR-0003)', async () => {
-      const { controller, rolesService } = makeController('app_user');
-      // role=platform_admin in the JWT/session — must NOT grant access to logs
-      await expect(
-        controller.getLogs(reqWith({ userId: 'u-padmin', role: 'platform_admin' })),
-      ).rejects.toBeInstanceOf(ForbiddenException);
-      // confirm SQLite was consulted (not short-circuited)
-      expect(rolesService.getAppRole).toHaveBeenCalledWith('u-padmin');
+    it('respects limit query param', async () => {
+      const { controller, logsService } = makeController();
+      await controller.getLogs('25');
+      expect(logsService.getAccessLogs).toHaveBeenCalledWith(25);
     });
   });
 
   describe('getStats', () => {
-    it('allows app_admin', async () => {
-      const { controller } = makeController('app_admin');
-      const result = await controller.getStats(reqWith({ userId: 'u-admin' }));
-      expect(result).toEqual({});
-    });
-
-    it('denies platform_admin with app_user SQLite role', async () => {
-      const { controller } = makeController('app_user');
-      await expect(
-        controller.getStats(reqWith({ userId: 'u-padmin', role: 'platform_admin' })),
-      ).rejects.toBeInstanceOf(ForbiddenException);
+    it('returns stats from service', async () => {
+      const { controller } = makeController();
+      const result = await controller.getStats();
+      expect(result).toEqual({ totalRequests: 42 });
     });
   });
 
   describe('getLogsByFrontend', () => {
-    it('allows app_admin', async () => {
-      const { controller } = makeController('app_admin');
-      const result = await controller.getLogsByFrontend(
-        reqWith({ userId: 'u-admin' }),
-        'frontend-app',
-      );
-      expect(result).toEqual([]);
-    });
-
-    it('denies platform_admin with app_user SQLite role', async () => {
-      const { controller } = makeController('app_user');
-      await expect(
-        controller.getLogsByFrontend(
-          reqWith({ userId: 'u-padmin', role: 'platform_admin' }),
-          'frontend-app',
-        ),
-      ).rejects.toBeInstanceOf(ForbiddenException);
+    it('delegates to service with frontend and limit', async () => {
+      const { controller, logsService } = makeController();
+      await controller.getLogsByFrontend('frontend-app', '50');
+      expect(logsService.getAccessLogsByFrontend).toHaveBeenCalledWith('frontend-app', 50);
     });
   });
 
   describe('getLogsByUser', () => {
-    it('allows app_admin', async () => {
-      const { controller } = makeController('app_admin');
-      const result = await controller.getLogsByUser(
-        reqWith({ userId: 'u-admin' }),
-        'some-user-id',
-      );
-      expect(result).toEqual([]);
-    });
-
-    it('denies platform_admin with app_user SQLite role', async () => {
-      const { controller } = makeController('app_user');
-      await expect(
-        controller.getLogsByUser(
-          reqWith({ userId: 'u-padmin', role: 'platform_admin' }),
-          'some-user-id',
-        ),
-      ).rejects.toBeInstanceOf(ForbiddenException);
+    it('delegates to service with userId and limit', async () => {
+      const { controller, logsService } = makeController();
+      await controller.getLogsByUser('user-uid', '10');
+      expect(logsService.getAccessLogsByUser).toHaveBeenCalledWith('user-uid', 10);
     });
   });
 });

--- a/api/src/demo/logs/logs.controller.ts
+++ b/api/src/demo/logs/logs.controller.ts
@@ -1,37 +1,28 @@
-import { Controller, Get, Query, Param, UseGuards, ForbiddenException, Request } from '@nestjs/common';
+import { Controller, Get, Query, Param, UseGuards } from '@nestjs/common';
 import { LogsService } from './logs.service';
-import { AuthenticatedGuard } from '../../guards/authenticated.guard';
-import { RolesService } from '../roles/roles.service';
+import { AppAdminGuard } from '../guards/app-admin.guard';
 
+/**
+ * Access gate: AppAdminGuard (class-level) enforces that the caller
+ * has app role app_admin in SQLite (ADR-0002 / ADR-0003, strict layering).
+ * platform_admin does NOT grant access — only SQLite app_admin does.
+ *
+ * The global AuthenticatedGuard (registered as APP_GUARD in AppModule)
+ * already ensures every caller is authenticated before AppAdminGuard runs.
+ */
 @Controller('logs')
-@UseGuards(AuthenticatedGuard)
+@UseGuards(AppAdminGuard)
 export class LogsController {
-  constructor(
-    private readonly logsService: LogsService,
-    private readonly rolesService: RolesService,
-  ) { }
-
-  // Helper to check if user has access. App role app_admin (SQLite, ADR-0002) is
-  // the sole gate — platform_admin does NOT grant log access (ADR-0003, strict layering).
-  private async checkAccess(user: any): Promise<boolean> {
-    // SQLite is the sole source of appRole (ADR-0002) — never read from JWT claim
-    const appRole = await this.rolesService.getAppRole(user.userId)
-    return appRole === 'app_admin'
-  }
+  constructor(private readonly logsService: LogsService) {}
 
   @Get()
   async getLogs(
-    @Request() req: any,
     @Query('limit') limit?: string,
     @Query('frontend') frontend?: string,
     @Query('method') method?: string,
     @Query('status') status?: string,
     @Query('path') path?: string,
   ) {
-    const user = req?.user
-    if (!user || !(await this.checkAccess(user))) {
-      throw new ForbiddenException('Access denied. Required app role: app_admin')
-    }
     const limitNum = limit ? parseInt(limit, 10) : 100;
     const hasFilters = method || status || path || frontend;
     if (hasFilters) {
@@ -46,30 +37,24 @@ export class LogsController {
   }
 
   @Get('stats')
-  async getStats(@Request() req: any) {
-    const user = req?.user
-    if (!user || !(await this.checkAccess(user))) {
-      throw new ForbiddenException('Access denied. Required app role: app_admin')
-    }
+  async getStats() {
     return this.logsService.getAccessStats();
   }
 
   @Get('frontend/:frontend')
-  async getLogsByFrontend(@Request() req: any, @Param('frontend') frontend: string, @Query('limit') limit?: string) {
-    const user = req?.user
-    if (!user || !(await this.checkAccess(user))) {
-      throw new ForbiddenException('Access denied. Required app role: app_admin')
-    }
+  async getLogsByFrontend(
+    @Param('frontend') frontend: string,
+    @Query('limit') limit?: string,
+  ) {
     const limitNum = limit ? parseInt(limit, 10) : 100;
     return this.logsService.getAccessLogsByFrontend(frontend, limitNum);
   }
 
   @Get('user/:userId')
-  async getLogsByUser(@Request() req: any, @Param('userId') userId: string, @Query('limit') limit?: string) {
-    const user = req?.user
-    if (!user || !(await this.checkAccess(user))) {
-      throw new ForbiddenException('Access denied. Required app role: app_admin')
-    }
+  async getLogsByUser(
+    @Param('userId') userId: string,
+    @Query('limit') limit?: string,
+  ) {
     const limitNum = limit ? parseInt(limit, 10) : 100;
     return this.logsService.getAccessLogsByUser(userId, limitNum);
   }

--- a/api/src/demo/logs/logs.module.ts
+++ b/api/src/demo/logs/logs.module.ts
@@ -3,10 +3,16 @@ import { LogsService } from './logs.service';
 import { LogsController } from './logs.controller';
 import { RolesModule } from '../roles/roles.module';
 
+/**
+ * LogsModule — access logs storage and retrieval.
+ *
+ * RolesModule is imported so AppAdminGuard (which depends on RolesService)
+ * can be resolved when applied to LogsController.
+ */
 @Module({
   imports: [RolesModule],
   providers: [LogsService],
   controllers: [LogsController],
   exports: [LogsService],
 })
-export class LogsModule { }
+export class LogsModule {}

--- a/api/src/demo/logs/logs.service.ts
+++ b/api/src/demo/logs/logs.service.ts
@@ -65,22 +65,19 @@ export class LogsService {
    * permanently bounded without requiring an external log-rotation daemon.
    */
   private async writeLogLine(line: string): Promise<void> {
+    // Check current file size; rotate if over the cap.
     try {
-      // Check current file size; rotate if over the cap.
-      try {
-        const stat = await fsPromises.stat(this.accessLogFile);
-        if (stat.size >= MAX_LOG_BYTES) {
-          const rotatedPath = `${this.accessLogFile}.1`;
-          await fsPromises.rename(this.accessLogFile, rotatedPath);
-        }
-      } catch {
-        // File doesn't exist yet — no rotation needed.
+      const stat = await fsPromises.stat(this.accessLogFile);
+      if (stat.size >= MAX_LOG_BYTES) {
+        const rotatedPath = `${this.accessLogFile}.1`;
+        await fsPromises.rename(this.accessLogFile, rotatedPath);
       }
-
-      await fsPromises.appendFile(this.accessLogFile, line, 'utf8');
-    } catch (err) {
-      throw err; // Re-throw so the caller's .catch() handles it.
+    } catch {
+      // File doesn't exist yet — no rotation needed.
     }
+
+    // Errors here propagate to the caller's .catch() in logAccess().
+    await fsPromises.appendFile(this.accessLogFile, line, 'utf8');
   }
 
   getAccessLogs(limit: number = 100): AccessLogEntry[] {

--- a/api/src/demo/logs/logs.service.ts
+++ b/api/src/demo/logs/logs.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
+
+/** Max file size before rotation (5 MiB). */
+const MAX_LOG_BYTES = 5 * 1024 * 1024;
 
 export interface AccessLogEntry {
   timestamp: string;
@@ -46,9 +50,37 @@ export class LogsService {
       this.accessLogs = this.accessLogs.slice(-1000);
     }
 
-    // Append to file
+    // Fire-and-forget async write so the event loop is never blocked (M-4).
     const logLine = JSON.stringify(entry) + '\n';
-    fs.appendFileSync(this.accessLogFile, logLine, 'utf8');
+    this.writeLogLine(logLine).catch((err: Error) => {
+      this.logger.error(`Failed to write access log: ${err.message}`);
+    });
+  }
+
+  /**
+   * Async file write with size-cap rotation.
+   *
+   * Before appending, stat the file; if it exceeds MAX_LOG_BYTES rotate it
+   * (rename access.log → access.log.1, start fresh).  This keeps the file
+   * permanently bounded without requiring an external log-rotation daemon.
+   */
+  private async writeLogLine(line: string): Promise<void> {
+    try {
+      // Check current file size; rotate if over the cap.
+      try {
+        const stat = await fsPromises.stat(this.accessLogFile);
+        if (stat.size >= MAX_LOG_BYTES) {
+          const rotatedPath = `${this.accessLogFile}.1`;
+          await fsPromises.rename(this.accessLogFile, rotatedPath);
+        }
+      } catch {
+        // File doesn't exist yet — no rotation needed.
+      }
+
+      await fsPromises.appendFile(this.accessLogFile, line, 'utf8');
+    } catch (err) {
+      throw err; // Re-throw so the caller's .catch() handles it.
+    }
   }
 
   getAccessLogs(limit: number = 100): AccessLogEntry[] {

--- a/api/src/demo/roles/README.md
+++ b/api/src/demo/roles/README.md
@@ -68,7 +68,15 @@ Requires: app_admin
 
 ## OAuth Integration
 
-When a user logs in via OAuth2 ("Login with Nova ID"), the `app_role` is included in the Hydra consent session and returned in token introspection. Oathkeeper's mutator reads it from `.Extra.ext.appRole` and sets `X-User-App-Role` header.
+`appRole` is **never** minted into a token and never set in any Oathkeeper header.
+Per [ADR-0002](../../../../docs/decisions/0002-idp-does-not-mint-approle.md), the
+IdP (Hydra consent session, Oathkeeper mutators) is Layer 2 and is intentionally
+kept unaware of application-level roles.
+
+`appRole` lives exclusively in the app's own database (SQLite, `data/app_roles.db`,
+Layer 3).  Every endpoint that needs it queries SQLite at request time via
+`RolesService.getAppRole()` — it is **never** read from a JWT claim or an
+Oathkeeper-forwarded header.
 
 ## Initial Setup
 

--- a/api/src/demo/roles/roles.controller.spec.ts
+++ b/api/src/demo/roles/roles.controller.spec.ts
@@ -1,0 +1,130 @@
+import { RolesController } from './roles.controller';
+
+/**
+ * RolesController audit-logging spec (Task 1 — M-1).
+ *
+ * Verifies AuditService.record is called with the correct action and
+ * metadata on every mutating handler.
+ */
+
+const DEMO_APP_ID = 'nova-id-test-app';
+
+function makeRolesService() {
+  return {
+    setAppRole: jest.fn().mockResolvedValue({ userId: 'target-u', appRole: 'app_admin' }),
+    getAppRole: jest.fn().mockResolvedValue('app_user'),
+    getAllUserRoles: jest.fn().mockResolvedValue([]),
+    getUserRole: jest.fn().mockResolvedValue(null),
+    deleteUserRole: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+function makeAudit() {
+  return { record: jest.fn().mockResolvedValue(undefined) } as any;
+}
+
+const actorUser = {
+  userId: 'actor-u1',
+  email: 'actor@nova.test',
+  role: 'platform_admin',
+  authMethod: 'jwt' as const,
+  jwtClaims: {},
+};
+
+describe('RolesController — audit logging (M-1)', () => {
+  describe('bootstrapAppAdmin', () => {
+    it('emits membership.grant with actor, target, and role in metadata', async () => {
+      const audit = makeAudit();
+      const ctrl = new RolesController(makeRolesService(), audit);
+
+      await ctrl.bootstrapAppAdmin(actorUser, { userId: 'target-u' });
+
+      expect(audit.record).toHaveBeenCalledTimes(1);
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 'actor-u1',
+          action: 'membership.grant',
+          targetId: 'target-u',
+          targetType: 'user',
+          appId: DEMO_APP_ID,
+          metadata: expect.objectContaining({ appRole: 'app_admin' }),
+        }),
+      );
+    });
+
+    it('uses actor userId as targetId when dto.userId is omitted', async () => {
+      const audit = makeAudit();
+      const ctrl = new RolesController(makeRolesService(), audit);
+
+      await ctrl.bootstrapAppAdmin(actorUser, {});
+
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetId: 'actor-u1',
+        }),
+      );
+    });
+  });
+
+  describe('setUserRole', () => {
+    it('emits membership.grant with the role in metadata', async () => {
+      const audit = makeAudit();
+      const ctrl = new RolesController(makeRolesService(), audit);
+
+      await ctrl.setUserRole('target-u', { appRole: 'app_admin' }, actorUser);
+
+      expect(audit.record).toHaveBeenCalledTimes(1);
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 'actor-u1',
+          action: 'membership.grant',
+          targetId: 'target-u',
+          targetType: 'user',
+          appId: DEMO_APP_ID,
+          metadata: expect.objectContaining({ appRole: 'app_admin' }),
+        }),
+      );
+    });
+  });
+
+  describe('updateUserRole', () => {
+    it('emits membership.grant (role change)', async () => {
+      const audit = makeAudit();
+      const ctrl = new RolesController(makeRolesService(), audit);
+
+      await ctrl.updateUserRole('target-u', { appRole: 'app_user' }, actorUser);
+
+      expect(audit.record).toHaveBeenCalledTimes(1);
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 'actor-u1',
+          action: 'membership.grant',
+          targetId: 'target-u',
+          targetType: 'user',
+          appId: DEMO_APP_ID,
+          metadata: expect.objectContaining({ appRole: 'app_user' }),
+        }),
+      );
+    });
+  });
+
+  describe('deleteUserRole', () => {
+    it('emits membership.revoke', async () => {
+      const audit = makeAudit();
+      const ctrl = new RolesController(makeRolesService(), audit);
+
+      await ctrl.deleteUserRole('target-u', actorUser);
+
+      expect(audit.record).toHaveBeenCalledTimes(1);
+      expect(audit.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 'actor-u1',
+          action: 'membership.revoke',
+          targetId: 'target-u',
+          targetType: 'user',
+          appId: DEMO_APP_ID,
+        }),
+      );
+    });
+  });
+});

--- a/api/src/demo/roles/roles.controller.ts
+++ b/api/src/demo/roles/roles.controller.ts
@@ -18,12 +18,19 @@ import { AuthenticatedUser } from '../../common/types/authenticated-user';
 import { BootstrapAppAdminDto } from './dto/bootstrap-app-admin.dto';
 import { SetUserRoleDto } from './dto/set-user-role.dto';
 import { LogAccess } from '../log-access.decorator';
+import { AuditService } from '../../audit/audit.service';
+
+/** The single application managed by the demo roles module. */
+const DEMO_APP_ID = process.env.APP_ID ?? 'nova-id-test-app';
 
 @Controller('roles')
 @UseGuards(AuthenticatedGuard)
 @LogAccess()
 export class RolesController {
-  constructor(private readonly rolesService: RolesService) { }
+  constructor(
+    private readonly rolesService: RolesService,
+    private readonly audit: AuditService,
+  ) {}
 
   // Bootstrap endpoint: platform_admin can set the first app_admin
   @Post('bootstrap/app-admin')
@@ -35,6 +42,14 @@ export class RolesController {
   ) {
     const targetUserId = dto.userId || user.userId;
     const userRole = await this.rolesService.setAppRole(targetUserId, 'app_admin');
+    await this.audit.record({
+      actorId: user.userId,
+      action: 'membership.grant',
+      appId: DEMO_APP_ID,
+      targetId: targetUserId,
+      targetType: 'user',
+      metadata: { appRole: 'app_admin' },
+    });
     return {
       message: `User ${targetUserId} set as app_admin (bootstrap)`,
       userRole,
@@ -83,8 +98,17 @@ export class RolesController {
   async setUserRole(
     @Param('userId') userId: string,
     @Body() dto: SetUserRoleDto,
+    @GetUser() user: AuthenticatedUser,
   ) {
     const userRole = await this.rolesService.setAppRole(userId, dto.appRole);
+    await this.audit.record({
+      actorId: user.userId,
+      action: 'membership.grant',
+      appId: DEMO_APP_ID,
+      targetId: userId,
+      targetType: 'user',
+      metadata: { appRole: dto.appRole },
+    });
     return {
       message: `User role set to ${dto.appRole}`,
       userRole,
@@ -96,8 +120,17 @@ export class RolesController {
   async updateUserRole(
     @Param('userId') userId: string,
     @Body() dto: SetUserRoleDto,
+    @GetUser() user: AuthenticatedUser,
   ) {
     const userRole = await this.rolesService.setAppRole(userId, dto.appRole);
+    await this.audit.record({
+      actorId: user.userId,
+      action: 'membership.grant',
+      appId: DEMO_APP_ID,
+      targetId: userId,
+      targetType: 'user',
+      metadata: { appRole: dto.appRole },
+    });
     return {
       message: `User role updated to ${dto.appRole}`,
       userRole,
@@ -106,8 +139,18 @@ export class RolesController {
 
   @Delete('user/:userId')
   @UseGuards(AppAdminGuard)
-  async deleteUserRole(@Param('userId') userId: string) {
+  async deleteUserRole(
+    @Param('userId') userId: string,
+    @GetUser() user: AuthenticatedUser,
+  ) {
     await this.rolesService.deleteUserRole(userId);
+    await this.audit.record({
+      actorId: user.userId,
+      action: 'membership.revoke',
+      appId: DEMO_APP_ID,
+      targetId: userId,
+      targetType: 'user',
+    });
     return {
       message: `User role deleted for ${userId}. Will default to app_user.`,
     };

--- a/api/src/demo/roles/roles.controller.ts
+++ b/api/src/demo/roles/roles.controller.ts
@@ -9,7 +9,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { RolesService } from './roles.service';
-import { AuthenticatedGuard } from '../../guards/authenticated.guard';
 import { AppAdminGuard } from '../guards/app-admin.guard';
 import { RoleGuard } from '../../guards/role.guard';
 import { RequireRole } from '../../decorators/require-role.decorator';
@@ -24,7 +23,6 @@ import { AuditService } from '../../audit/audit.service';
 const DEMO_APP_ID = process.env.APP_ID ?? 'nova-id-test-app';
 
 @Controller('roles')
-@UseGuards(AuthenticatedGuard)
 @LogAccess()
 export class RolesController {
   constructor(

--- a/api/src/demo/roles/roles.module.ts
+++ b/api/src/demo/roles/roles.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { RolesController } from './roles.controller';
 import { RolesService } from './roles.service';
 import { UserRole } from './entities/user-role.entity';
+import { AuditModule } from '../../audit/audit.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserRole])],
+  imports: [TypeOrmModule.forFeature([UserRole]), AuditModule],
   controllers: [RolesController],
   providers: [RolesService],
   exports: [RolesService],
 })
-export class RolesModule { }
+export class RolesModule {}


### PR DESCRIPTION
Resolves code-review findings M-1, M-2, M-4, M-5, L-BFF, ADR-0002 README (all validated REAL).

- **M-1** AuditService now records `membership.grant`/`revoke` (4 role handlers incl. bootstrapAppAdmin) + `consent.deny` (Keto fail-closed path).
- **M-2** access log no longer trusts spoofable `x-user-*` headers; defaults to `anonymous`.
- **M-4** async + 5MiB-rotated access-log writes (was sync `appendFileSync`).
- **M-5** consent path typed (`AuthenticatedUser`, `AcceptHydraConsentDto`), no `as any`.
- **L-BFF** removed redundant global guard re-application; `logs.controller` uses `AppAdminGuard` (identical semantics); demo-seed fetch now paginated + timeout.
- **ADR-0002** `roles/README.md` OAuth section rewritten (appRole is SQLite-only, never in token/header).

85 tests pass, typecheck clean.