### PR TITLE
fix(frontend): CSPRNG OAuth secrets, validate id_token iss/aud, block open redirects

### DIFF
--- a/frontend-app/src/composables/useHydraOAuth.ts
+++ b/frontend-app/src/composables/useHydraOAuth.ts
@@ -24,9 +24,17 @@ const ID_TOKEN_CLOCK_SKEW_SEC = 60
 
 function generateRandomString(length = 43) {
   const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'
+  // Use CSPRNG. Rejection sampling: discard bytes that would introduce modulo bias.
+  // charset.length = 66; mask = 0x7f (127) keeps all 66 values within a 7-bit window
+  // (66 < 128), guaranteeing a rejection rate below 50% per byte.
+  const mask = (1 << Math.ceil(Math.log2(charset.length + 1))) - 1
   let result = ''
-  for (let i = 0; i < length; i++) {
-    result += charset.charAt(Math.floor(Math.random() * charset.length))
+  while (result.length < length) {
+    const bytes = crypto.getRandomValues(new Uint8Array(length - result.length))
+    for (const byte of bytes) {
+      const idx = byte & mask
+      if (idx < charset.length) result += charset[idx]
+    }
   }
   return result
 }
@@ -104,7 +112,7 @@ export async function handleOAuthCallback(code: string, state: string): Promise<
   const storedNonce = sessionStorage.getItem(OAUTH_STORAGE_PREFIX + 'nonce')
   if (tokens.id_token) {
     const claims = decodeIdToken(tokens.id_token)
-    validateIdTokenClaims(claims)
+    validateIdTokenClaims(claims, getHydraPublicUrl(), clientId)
     if (storedNonce && claims.nonce && claims.nonce !== storedNonce) {
       sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'code_verifier')
       sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'state')
@@ -131,18 +139,46 @@ export function decodeIdToken(idToken: string): IdTokenClaims {
 }
 
 /**
- * Validate id_token claims (exp, iat) per OIDC. Optional clock skew applied.
+ * Normalise an issuer URL for comparison by stripping a trailing slash.
+ * Hydra emits the issuer exactly as configured in urls.self.issuer (no trailing slash),
+ * but VITE_HYDRA_PUBLIC_URL may vary in local environments. Strip both sides to be safe.
+ */
+function normaliseIssuer(url: string) {
+  return url.replace(/\/$/, '')
+}
+
+/**
+ * Validate id_token claims (exp, iat, iss, aud) per OIDC. Optional clock skew applied.
  * @param claims - Decoded id_token payload
+ * @param expectedIssuer - Exact issuer from Hydra config (e.g. http://api.ory.localhost)
+ * @param clientId - OAuth client_id that must appear in aud
  * @param clockSkewSec - Allowed skew in seconds (default 60)
  */
-export function validateIdTokenClaims(claims: IdTokenClaims, clockSkewSec: number = ID_TOKEN_CLOCK_SKEW_SEC) {
+export function validateIdTokenClaims(
+  claims: IdTokenClaims,
+  expectedIssuer: string,
+  clientId: string,
+  clockSkewSec: number = ID_TOKEN_CLOCK_SKEW_SEC
+) {
   if (!claims || typeof claims !== 'object') throw new Error('Invalid id_token claims')
+
   const now = Math.floor(Date.now() / 1000)
   if (claims.exp != null) {
     if (now > claims.exp + clockSkewSec) throw new Error('id_token expired')
   }
   if (claims.iat != null) {
     if (now < claims.iat - clockSkewSec) throw new Error('id_token not yet valid (iat in future)')
+  }
+
+  // iss validation — normalise both sides to tolerate trailing-slash mismatch
+  if (!claims.iss || normaliseIssuer(claims.iss) !== normaliseIssuer(expectedIssuer)) {
+    throw new Error(`id_token issuer mismatch: expected "${expectedIssuer}", got "${claims.iss}"`)
+  }
+
+  // aud validation — OIDC §2: aud MUST be the client_id (string or array)
+  const audList = Array.isArray(claims.aud) ? claims.aud : [claims.aud]
+  if (!claims.aud || !audList.includes(clientId)) {
+    throw new Error(`id_token audience does not include client "${clientId}"`)
   }
 }
 

--- a/frontend-app/src/types.ts
+++ b/frontend-app/src/types.ts
@@ -55,6 +55,9 @@ export interface TokenResponse {
 export interface IdTokenClaims {
   exp?: number
   iat?: number
+  iss?: string
+  /** aud may be a single string or an array per OIDC §2. */
+  aud?: string | string[]
   nonce?: string
   [key: string]: unknown
 }

--- a/frontend-auth/src/utils/safeRedirect.test.ts
+++ b/frontend-auth/src/utils/safeRedirect.test.ts
@@ -44,6 +44,18 @@ describe('safeRedirect', () => {
     expect(safeRedirect('//evil.example.com/path', '/')).toBe('/')
   })
 
+  it('rejects a backslash bypass /\\evil.com (browsers normalise \\ to /)', () => {
+    expect(safeRedirect('/\\evil.com', '/')).toBe('/')
+  })
+
+  it('rejects a mixed slash-backslash bypass /\\/evil.com', () => {
+    expect(safeRedirect('/\\/evil.com', '/')).toBe('/')
+  })
+
+  it('rejects a leading-backslash bypass \\/evil.com', () => {
+    expect(safeRedirect('\\/evil.com', '/')).toBe('/')
+  })
+
   it('returns fallback for null input', () => {
     expect(safeRedirect(null, '/home')).toBe('/home')
   })

--- a/frontend-auth/src/utils/safeRedirect.test.ts
+++ b/frontend-auth/src/utils/safeRedirect.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for safeRedirect.
+ *
+ * NOTE: frontend-auth has no test runner configured (no vitest.config.ts).
+ * These tests are written in Vitest style and will run once vitest is added.
+ * To enable: `pnpm add -D vitest` in frontend-auth and add a vitest.config.ts.
+ *
+ * The jsdom environment is assumed (Vitest's default) so `window.location.origin`
+ * resolves to "http://localhost".  `import.meta.env.*` is provided via vi.stubEnv.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { safeRedirect } from './safeRedirect'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('safeRedirect', () => {
+  it('allows a same-origin relative path', () => {
+    expect(safeRedirect('/dashboard', '/')).toBe('/dashboard')
+  })
+
+  it('allows a relative path with query string', () => {
+    expect(safeRedirect('/login?return_to=foo', '/')).toBe('/login?return_to=foo')
+  })
+
+  it('rejects an off-site absolute URL and returns fallback', () => {
+    expect(safeRedirect('https://evil.example.com/steal', '/')).toBe('/')
+  })
+
+  it('rejects a javascript: URI and returns fallback', () => {
+    expect(safeRedirect('javascript:alert(1)', '/')).toBe('/')
+  })
+
+  it('rejects a javascript: URI with leading whitespace', () => {
+    expect(safeRedirect('  javascript:alert(1)', '/')).toBe('/')
+  })
+
+  it('rejects a data: URI and returns fallback', () => {
+    expect(safeRedirect('data:text/html,<script>alert(1)</script>', '/')).toBe('/')
+  })
+
+  it('rejects a protocol-relative URL pointing off-site', () => {
+    expect(safeRedirect('//evil.example.com/path', '/')).toBe('/')
+  })
+
+  it('returns fallback for null input', () => {
+    expect(safeRedirect(null, '/home')).toBe('/home')
+  })
+
+  it('returns fallback for undefined input', () => {
+    expect(safeRedirect(undefined, '/home')).toBe('/home')
+  })
+
+  it('returns fallback for empty string', () => {
+    expect(safeRedirect('', '/home')).toBe('/home')
+  })
+
+  it('allows an extra origin listed in VITE_ALLOWED_REDIRECT_ORIGINS', () => {
+    vi.stubEnv('VITE_ALLOWED_REDIRECT_ORIGINS', 'https://app.example.com')
+    expect(safeRedirect('https://app.example.com/callback', '/')).toBe('https://app.example.com/callback')
+  })
+
+  it('rejects an origin NOT in VITE_ALLOWED_REDIRECT_ORIGINS', () => {
+    vi.stubEnv('VITE_ALLOWED_REDIRECT_ORIGINS', 'https://app.example.com')
+    expect(safeRedirect('https://other.example.com/path', '/')).toBe('/')
+  })
+})

--- a/frontend-auth/src/utils/safeRedirect.ts
+++ b/frontend-auth/src/utils/safeRedirect.ts
@@ -1,0 +1,57 @@
+/**
+ * safeRedirect — validate a redirect URL before use (H-6: open-redirect prevention).
+ *
+ * Rules:
+ *  1. Relative paths (no host) are always allowed — they resolve to the current origin.
+ *  2. Absolute URLs are allowed only if their origin is in the allowlist:
+ *     - current window.location.origin (always)
+ *     - any origins from VITE_ALLOWED_REDIRECT_ORIGINS (comma-separated, optional)
+ *  3. `javascript:` and `data:` scheme URLs are always rejected.
+ *  4. Malformed / unparseable URLs fall back to `fallback`.
+ *
+ * @param url      - Candidate redirect URL (may be null/undefined/empty).
+ * @param fallback - Safe fallback path returned when `url` is rejected.
+ */
+export function safeRedirect(url: string | null | undefined, fallback: string): string {
+  if (!url) return fallback
+
+  // Reject dangerous schemes early (before URL parsing normalises them)
+  const lower = url.toLowerCase().replace(/\s/g, '')
+  if (lower.startsWith('javascript:') || lower.startsWith('data:')) return fallback
+
+  // Relative paths (starting with / but not //) are always safe — they stay on the current origin.
+  // Protocol-relative URLs (starting with //) are treated as absolute and must pass origin check.
+  if (url.startsWith('/') && !url.startsWith('//')) return url
+
+  // Parse as absolute URL
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    // Not a valid absolute URL — treat as a relative path only if it looks safe
+    // (no scheme, no //). For safety, fall back.
+    return fallback
+  }
+
+  // Reject any scheme that is not http or https
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return fallback
+
+  // Build allowlist: current origin + any VITE_ALLOWED_REDIRECT_ORIGINS
+  const allowedOrigins = new Set<string>()
+
+  if (typeof window !== 'undefined') {
+    allowedOrigins.add(window.location.origin)
+  }
+
+  const envOrigins = import.meta.env.VITE_ALLOWED_REDIRECT_ORIGINS
+  if (envOrigins) {
+    for (const raw of envOrigins.split(',')) {
+      const trimmed = raw.trim()
+      if (trimmed) allowedOrigins.add(trimmed)
+    }
+  }
+
+  if (allowedOrigins.has(parsed.origin)) return url
+
+  return fallback
+}

--- a/frontend-auth/src/utils/safeRedirect.ts
+++ b/frontend-auth/src/utils/safeRedirect.ts
@@ -21,7 +21,10 @@ export function safeRedirect(url: string | null | undefined, fallback: string): 
 
   // Relative paths (starting with / but not //) are always safe — they stay on the current origin.
   // Protocol-relative URLs (starting with //) are treated as absolute and must pass origin check.
-  if (url.startsWith('/') && !url.startsWith('//')) return url
+  // Backslashes are rejected: browsers normalise `\` to `/`, so `/\evil.com` would resolve
+  // off-origin. Any candidate containing `\` falls through to URL parsing (throws → fallback)
+  // instead of being trusted as a relative path.
+  if (url.startsWith('/') && !url.startsWith('//') && !url.includes('\\')) return url
 
   // Parse as absolute URL
   let parsed: URL

--- a/frontend-auth/src/views/Login.vue
+++ b/frontend-auth/src/views/Login.vue
@@ -239,6 +239,7 @@ import { createLoginFlow, getLoginFlow, updateLoginFlow } from '../composables/u
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
+import { safeRedirect } from '../utils/safeRedirect'
 
 const refreshAuth = inject<(() => Promise<void>) | null>('refreshAuth', null)
 import {
@@ -430,7 +431,8 @@ const handleSubmit = async (event: Event) => {
     }
     
     const payload = Object.fromEntries(formData.entries())
-    const data = (await updateLoginFlow(flow.value!.id!, payload as unknown as UpdateLoginFlowBody)) as unknown as FlowLike
+    if (!flow.value?.id) return
+    const data = (await updateLoginFlow(flow.value.id, payload as unknown as UpdateLoginFlowBody)) as unknown as FlowLike
 
     // For browser-based login, if we get here without an error, login succeeded
     // Session is set as a cookie, not in the response body
@@ -446,12 +448,9 @@ const handleSubmit = async (event: Event) => {
       // Prefer intended return URL (OAuth hydra-callback), then flow/query
       const returnTo = intendedReturnUrl.value || flow.value?.return_to || firstQuery(route.query.return_to) || firstQuery(route.query.returnTo)
 
-      if (returnTo) {
-        window.location.href = decodeURIComponent(returnTo)
-      } else {
-        const adminUrl = import.meta.env.VITE_ADMIN_URL || 'http://admin.ory.localhost'
-        window.location.href = `${adminUrl}/dashboard`
-      }
+      const adminUrl = import.meta.env.VITE_ADMIN_URL || 'http://admin.ory.localhost'
+      const destination = safeRedirect(returnTo ? decodeURIComponent(returnTo) : null, `${adminUrl}/dashboard`)
+      window.location.href = destination
     } else {
       // Response has errors: check for verification required (continue_with in success body)
       const continueWith = getContinueWith(data)

--- a/frontend-auth/src/views/Recovery.vue
+++ b/frontend-auth/src/views/Recovery.vue
@@ -224,6 +224,7 @@ import { createRecoveryFlow, getRecoveryFlow, updateRecoveryFlow } from '../comp
 import type { FlowLike, HttpErrorLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
+import { safeRedirect } from '../utils/safeRedirect'
 import {
   getNodeValue,
   getNodeName,
@@ -469,10 +470,11 @@ const handleSubmit = async (event: Event) => {
       
       if (hasSession) {
         // Recovery successful - redirect to return_to if provided, else login with recovered flag
-        if (returnTo.value) {
-          window.location.href = decodeURIComponent(returnTo.value)
+        const destination = safeRedirect(returnTo.value ? decodeURIComponent(returnTo.value) : null, '/login?recovered=true')
+        if (destination.startsWith('/')) {
+          router.push(destination)
         } else {
-          router.push('/login?recovered=true')
+          window.location.href = destination
         }
       } else if (hasPasswordField) {
         flow.value = data

--- a/frontend-auth/src/views/Registration.vue
+++ b/frontend-auth/src/views/Registration.vue
@@ -224,6 +224,7 @@ import { createRegistrationFlow, getRegistrationFlow, updateRegistrationFlow } f
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
+import { safeRedirect } from '../utils/safeRedirect'
 import {
   getNodeValue,
   getNodeName,
@@ -452,10 +453,11 @@ const handleSubmit = async (event: Event) => {
     }
 
     const redirectAfter = () => {
-      if (returnTo.value) {
-        window.location.href = decodeURIComponent(returnTo.value)
+      const destination = safeRedirect(returnTo.value ? decodeURIComponent(returnTo.value) : null, '/dashboard')
+      if (destination.startsWith('/')) {
+        router.push(destination)
       } else {
-        router.push('/dashboard')
+        window.location.href = destination
       }
     }
 

--- a/frontend-auth/src/views/Settings.vue
+++ b/frontend-auth/src/views/Settings.vue
@@ -208,6 +208,7 @@ import { getSettingsFlow, updateSettingsFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
+import { safeRedirect } from '../utils/safeRedirect'
 import {
   getNodeValue,
   getNodeName,
@@ -492,10 +493,11 @@ const handleSubmit = async (event: Event) => {
       if (hasSuccess || data?.state === 'success') {
         // Password reset successful - redirect to return_to if provided (e.g. from recovery), else dashboard
         const returnTo = firstQuery(route.query.return_to) || firstQuery(route.query.returnTo)
-        if (returnTo) {
-          window.location.href = decodeURIComponent(returnTo)
+        const destination = safeRedirect(returnTo ? decodeURIComponent(returnTo) : null, '/dashboard?password_reset=true')
+        if (destination.startsWith('/')) {
+          router.push(destination)
         } else {
-          router.push('/dashboard?password_reset=true')
+          window.location.href = destination
         }
       } else {
         // Update flow with new state

--- a/frontend-auth/src/views/Verification.vue
+++ b/frontend-auth/src/views/Verification.vue
@@ -265,6 +265,7 @@ import { createBrowserVerificationFlow, getVerificationFlow, updateVerificationF
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
+import { safeRedirect } from '../utils/safeRedirect'
 import {
   getNodeValue,
   getNodeName,
@@ -542,7 +543,7 @@ const handleSubmit = async (event: Event) => {
       const stillVerificationStep = continueWith.some(c => c.action === 'show_verification_ui')
 
       if (hasSession) {
-        const target = returnTo.value ? decodeURIComponent(returnTo.value) : DEFAULT_AFTER_VERIFICATION
+        const target = safeRedirect(returnTo.value ? decodeURIComponent(returnTo.value) : null, DEFAULT_AFTER_VERIFICATION)
         window.location.href = target
       } else if (stillVerificationStep) {
         flow.value = data

--- a/frontend-auth/tsconfig.json
+++ b/frontend-auth/tsconfig.json
@@ -7,5 +7,6 @@
     "types": ["vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"],
+  "exclude": ["src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Resolves code-review findings H-4, H-5, H-6 + L (double non-null) — all validated REAL.

- **H-4** PKCE `code_verifier`/`state`/`nonce` now use `crypto.getRandomValues` (rejection sampling, unbiased) instead of `Math.random()`.
- **H-5** `validateIdTokenClaims` now asserts `iss` (== Hydra issuer, trailing-slash normalized) and `aud` (includes client_id, string|array per OIDC).
- **H-6** new `safeRedirect()` util (origin allowlist + reject `javascript:`/`data:`/off-site) applied to all 5 `return_to` sinks (Login/Registration/Recovery/Settings/Verification).
- **L** Login.vue double non-null `flow.value!.id!` → guarded early-return.

Typecheck clean (frontend-app, frontend-auth). Note: frontend-auth has no test runner yet → safeRedirect.test.ts is dead-letter until CI/vitest lands (tracked under B-1).