### PR TITLE
fix(frontend): hygiene sweep — modal, route guard, dead code, error logging

### DIFF
--- a/frontend-admin/src/composables/useAuth.ts
+++ b/frontend-admin/src/composables/useAuth.ts
@@ -43,7 +43,7 @@ export async function checkSession(): Promise<Session | null> {
   try {
     logger.log('checkSession - Calling toSession() via Oathkeeper at:', oathkeeperUrl)
     const { data } = await ory.toSession()
-    logger.log('checkSession - Session found:', data ? 'Yes' : 'No', data?.identity?.id ? `User: ${data.identity.id}` : '')
+    logger.log('checkSession - Session found:', data ? 'Yes' : 'No')
     return data
   } catch (error) {
     // 401 is expected when there's no session - don't log as error

--- a/frontend-admin/src/composables/useHydra.ts
+++ b/frontend-admin/src/composables/useHydra.ts
@@ -138,27 +138,3 @@ export async function deleteClient(clientId: string): Promise<boolean> {
     throw error
   }
 }
-
-// List OAuth2 access tokens (for testing)
-export async function listAccessTokens(): Promise<unknown> {
-  try {
-    const response = await fetch(`${hydraAdminUrl}/oauth2/tokens`, {
-      method: 'GET',
-      credentials: 'include',
-      mode: 'cors',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error(`Failed to list tokens: ${response.statusText}`)
-    }
-
-    return await response.json()
-  } catch (error) {
-    logger.error('Error listing tokens:', errMessage(error))
-    throw error
-  }
-}

--- a/frontend-admin/src/main.ts
+++ b/frontend-admin/src/main.ts
@@ -4,7 +4,7 @@ import type { RouteRecordRaw } from 'vue-router'
 import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
 import '../style.css'
 import { validateEnv } from './config/env'
-import { logger } from './utils/logger'
+import { logger, errMessage } from './utils/logger'
 import { setGlobalError } from './state/errorState'
 import App from './App.vue'
 import Home from './views/Home.vue'
@@ -50,7 +50,7 @@ router.beforeEach(async (to, _from, next) => {
         }
       }
     } catch (error) {
-      logger.error('Navigation guard: Auth check failed', error)
+      logger.error('Navigation guard: Auth check failed', errMessage(error))
       next({ path: '/' })
       return
     }
@@ -69,7 +69,7 @@ const queryClient = new QueryClient({
 
 const app = createApp(App)
 app.config.errorHandler = (err, _instance, info) => {
-  logger.error('Uncaught error', err, info)
+  logger.error('Uncaught error', errMessage(err), String(info))
   setGlobalError(err)
 }
 app.use(router)

--- a/frontend-admin/src/views/PermissionsManagement.vue
+++ b/frontend-admin/src/views/PermissionsManagement.vue
@@ -107,13 +107,36 @@
                     </p>
                   </div>
                   <button
-                    @click="deleteOAuthClient(client.client_id)"
+                    @click="clientToDelete = client.client_id"
                     class="px-3 py-1 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30 transition-colors text-sm"
                   >
                     Delete
                   </button>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Delete OAuth Client Confirmation Modal -->
+        <div
+          v-if="clientToDelete"
+          class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          @click.self="clientToDelete = null"
+        >
+          <div class="card mx-4 w-full max-w-md p-6 shadow-modal">
+            <h3 class="text-lg font-semibold text-red-400 mb-4">Delete OAuth client</h3>
+            <p class="text-cyber-light mb-4">
+              Are you sure you want to delete client <code class="text-cyber-light font-mono">{{ clientToDelete }}</code>?
+              This action cannot be undone.
+            </p>
+            <div class="flex justify-end gap-3 pt-4">
+              <button type="button" @click="clientToDelete = null" class="btn-secondary">
+                Cancel
+              </button>
+              <button type="button" @click="deleteOAuthClient" class="btn-danger disabled:opacity-50">
+                Delete
+              </button>
             </div>
           </div>
         </div>
@@ -191,6 +214,7 @@ const success = ref<string | null>(null)
 const oauthClients = ref<OAuthClient[]>([])
 const creatingClient = ref(false)
 const showCreateClient = ref(false)
+const clientToDelete = ref<string | null>(null)
 
 const clientForm = ref({
   client_name: '',
@@ -259,9 +283,11 @@ const createOAuthClient = async () => {
   }
 }
 
-const deleteOAuthClient = async (clientId: string) => {
-  if (!confirm('Are you sure you want to delete this OAuth client?')) return
+const deleteOAuthClient = async () => {
+  if (!clientToDelete.value) return
 
+  const clientId = clientToDelete.value
+  clientToDelete.value = null
   error.value = null
   success.value = null
   try {

--- a/frontend-admin/src/views/UsersManagement.vue
+++ b/frontend-admin/src/views/UsersManagement.vue
@@ -243,8 +243,8 @@
                     type="button"
                     @click="viewPermissions(user)"
                     class="action-btn action-btn--icon action-btn--secondary"
-                    title="View permissions"
-                    aria-label="View permissions"
+                    title="View your permissions"
+                    aria-label="View your permissions"
                   >
                     <svg class="action-btn__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />

--- a/frontend-app/src/main.ts
+++ b/frontend-app/src/main.ts
@@ -7,6 +7,8 @@ import Logs from './views/Logs.vue'
 import Callback from './views/Callback.vue'
 import About from './views/About.vue'
 import Architecture from './views/Architecture.vue'
+import { getApiTestBaseUrl } from './composables/useApiTest'
+import type { MeResponse, DemoUser } from './types'
 
 const routes: RouteRecordRaw[] = [
   { path: '/', name: 'Home', component: Home },
@@ -19,6 +21,32 @@ const routes: RouteRecordRaw[] = [
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+// Navigation guard: enforce requiresPlatformAdmin routes.
+// Uses the same /api-test/me + appRole === 'app_admin' check as Logs.vue
+// (ADR-0002: SQLite appRole is the sole gate — platform_admin alone is not sufficient).
+router.beforeEach(async (to, _from, next) => {
+  if (!to.meta.requiresPlatformAdmin) {
+    next()
+    return
+  }
+
+  try {
+    const res = await fetch(`${getApiTestBaseUrl()}/me`, { credentials: 'include' })
+    if (res.ok) {
+      const me = await res.json() as MeResponse
+      const user: DemoUser = me.user ?? (me as unknown as DemoUser)
+      if (user?.appRole === 'app_admin') {
+        next()
+        return
+      }
+    }
+  } catch {
+    // fetch failure → deny access (fail-closed)
+  }
+
+  next({ path: '/' })
 })
 
 const app = createApp(App)

--- a/frontend-app/src/views/Home.vue
+++ b/frontend-app/src/views/Home.vue
@@ -505,8 +505,11 @@ async function runTest(ep: Endpoint) {
 
     const response = await fetch(url, options)
     if (!response.ok) {
-      const errorText = await response.text().catch(() => response.statusText)
-      throw new Error(`API request failed: ${response.status} ${response.statusText} - ${errorText}`)
+      const errorText = import.meta.env.DEV
+        ? await response.text().catch(() => response.statusText)
+        : null
+      const detail = errorText ? ` - ${errorText}` : ''
+      throw new Error(`API request failed: ${response.status} ${response.statusText}${detail}`)
     }
     apiResponse.value = await response.json()
   } catch (err) {


### PR DESCRIPTION
Resolves M-8, M-9, M-10, M-11, M-12 + L-frontend (validated; M-8/M-9 PARTIAL).

- M-11 remove dead `listAccessTokens()` (Hydra-Admin call, 0 callers)
- M-12 native `confirm()` → inline modal (matches UsersManagement pattern)
- M-9 rename misleading 'View permissions' → 'View your permissions'
- M-10 frontend-app `router.beforeEach` consumes `requiresPlatformAdmin` (reuses existing app_admin SQLite check; in-component guard kept as defense-in-depth)
- M-8 `errMessage()` used consistently in admin main.ts
- L-fe drop identity.id from dev log; prod truncates API error body to status only