### PR TITLE
fix(audit): TypeORM migrations + DataSource for audit connection (M-3)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,11 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "openapi:gen": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
-    "openapi:verify": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts && git diff --exit-code -- openapi.json"
+    "openapi:verify": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts && git diff --exit-code -- openapi.json",
+    "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/audit/audit.datasource.ts",
+    "migration:run": "typeorm-ts-node-commonjs migration:run -d src/audit/audit.datasource.ts",
+    "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/audit/audit.datasource.ts",
+    "migration:show": "typeorm-ts-node-commonjs migration:show -d src/audit/audit.datasource.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.3.0",

--- a/api/src/audit/audit.datasource.ts
+++ b/api/src/audit/audit.datasource.ts
@@ -1,0 +1,31 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { AuditLog } from './audit-log.entity';
+
+/**
+ * Standalone DataSource used exclusively by the TypeORM CLI (migration:generate,
+ * migration:run, migration:revert). It is NOT imported by the NestJS app module
+ * — the app uses TypeOrmModule.forRoot() in AuditModule.
+ *
+ * Connection parameters mirror audit.module.ts exactly: all read from the same
+ * AUDIT_DB_* environment variables so the same .env file drives both paths.
+ *
+ * Required export name: "default" — TypeORM CLI requires a default export.
+ */
+const AuditDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.AUDIT_DB_HOST ?? 'localhost',
+  port: parseInt(process.env.AUDIT_DB_PORT ?? '5432', 10),
+  username: process.env.AUDIT_DB_USER ?? 'postgres',
+  password: process.env.AUDIT_DB_PASSWORD,
+  database: process.env.AUDIT_DB_NAME ?? 'nova_audit',
+  entities: [AuditLog],
+  migrations: ['src/audit/migrations/*.ts'],
+  /**
+   * synchronize MUST be false here. This DataSource is for migrations only;
+   * auto-sync would race with (and potentially corrupt) the migration state.
+   */
+  synchronize: false,
+});
+
+export default AuditDataSource;

--- a/api/src/audit/audit.module.ts
+++ b/api/src/audit/audit.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuditLog } from './audit-log.entity';
 import { AuditService } from './audit.service';
+import { CreateAuditLogs1781750293893 } from './migrations/1781750293893-CreateAuditLogs';
 
 /**
  * AuditModule — registers a NAMED 'audit' TypeORM connection backed by
@@ -11,8 +12,13 @@ import { AuditService } from './audit.service';
  * treating it as the default connection and avoids conflicts with the
  * existing SQLite 'default' connection registered by DemoModule.
  *
- * synchronize=true in non-production is intentional for local dev only;
- * production must use explicit migrations (follow-up task A2-plan-2).
+ * Schema management: migrations only, in ALL environments.
+ * - synchronize: false — never auto-mutate the schema. Use `npm run migration:generate`
+ *   to produce a migration and `npm run migration:run` to apply it.
+ * - migrationsRun: true — TypeORM runs pending migrations on every boot, so
+ *   the table is created automatically in fresh dev/staging/prod environments
+ *   without any manual step.
+ * - The standalone DataSource for the CLI lives in audit.datasource.ts.
  */
 @Module({
   imports: [
@@ -25,9 +31,9 @@ import { AuditService } from './audit.service';
       password: process.env.AUDIT_DB_PASSWORD,
       database: process.env.AUDIT_DB_NAME,
       entities: [AuditLog],
-      // Dev-only schema sync: creates audit_logs on first boot. Never in production —
-      // use explicit TypeORM migrations instead (follow-up).
-      synchronize: process.env.NODE_ENV !== 'production',
+      migrations: [CreateAuditLogs1781750293893],
+      synchronize: false,
+      migrationsRun: true,
     }),
     TypeOrmModule.forFeature([AuditLog], 'audit'),
   ],

--- a/api/src/audit/migrations/1781750293893-CreateAuditLogs.ts
+++ b/api/src/audit/migrations/1781750293893-CreateAuditLogs.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateAuditLogs1781750293893 implements MigrationInterface {
+    name = 'CreateAuditLogs1781750293893'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "audit_logs" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "actorId" character varying NOT NULL, "actorEmail" character varying, "action" character varying NOT NULL, "appId" character varying, "targetId" character varying, "targetType" character varying, "metadata" jsonb, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1bb179d048bbc581caa3b013439" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_2dc33f7f3c22e2e7badafca1d1" ON "audit_logs" ("actorId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_cee5459245f652b75eb2759b4c" ON "audit_logs" ("action") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_cee5459245f652b75eb2759b4c"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2dc33f7f3c22e2e7badafca1d1"`);
+        await queryRunner.query(`DROP TABLE "audit_logs"`);
+    }
+
+}

--- a/api/src/demo/demo.module.ts
+++ b/api/src/demo/demo.module.ts
@@ -15,7 +15,12 @@ import { UserRole } from './roles/entities/user-role.entity';
       type: 'sqlite',
       database: 'data/app_roles.db',
       entities: [UserRole],
-      // synchronize is dev-only: never auto-migrate schema in production.
+      // synchronize is intentionally left enabled for non-production here.
+      // Rationale (ADR-0001): the demo SQLite DB is ephemeral and dev/demo-only;
+      // it is never deployed to production. Auto-sync is harmless on a local,
+      // disposable file-based DB and avoids the overhead of maintaining SQLite
+      // migrations for a module that exists only to support local demos.
+      // If this module is ever promoted to a real environment, migrate it properly.
       synchronize: process.env.NODE_ENV !== 'production',
     }),
     RolesModule,


### PR DESCRIPTION
Resolves M-3 (prod-readiness).

- Standalone `audit.datasource.ts` (audit Postgres conn, `synchronize:false`)
- Initial migration `CreateAuditLogs` (table + actorId/action indexes, append-only shape)
- `audit.module.ts`: `synchronize:false` + `migrationsRun:true` → table auto-created on boot in every env
- demo SQLite conn left `synchronize` gated (dev/demo-only per ADR-0001) with explicit comment
- Verified: migration runs, `audit_logs` created, 85/85 tests green