### PR TITLE
fix(auth): stop dumping app users into admin after email verification

### DIFF
--- a/config/kratos/kratos.local.yml
+++ b/config/kratos/kratos.local.yml
@@ -36,7 +36,10 @@ serve:
     base_url: http://localhost:4434/
 
 selfservice:
-  default_browser_return_url: http://admin.ory.localhost/dashboard
+  # Neutral fallback for flows that complete WITHOUT a return_to (multi-app IdP:
+  # admin/dashboard is the wrong default — most users aren't admins). Per-flow
+  # return_to / after_verification_return_to override this when context exists.
+  default_browser_return_url: http://auth.ory.localhost/auth/login
   allowed_return_urls:
     - http://auth.ory.localhost
     - http://auth.ory.localhost/auth/hydra-callback
@@ -87,11 +90,14 @@ selfservice:
       ui_url: http://auth.ory.localhost/auth/verification
       use: code
       after:
-        default_browser_return_url: http://admin.ory.localhost/dashboard
+        # Neutral fallback when the verification flow has no return_to /
+        # after_verification_return_to (e.g. an app user clicking the email link
+        # without context). Was admin/dashboard → wrongly dumped app users in admin.
+        default_browser_return_url: http://auth.ory.localhost/auth/login
 
     logout:
       after:
-        default_browser_return_url: http://admin.ory.localhost/
+        default_browser_return_url: http://auth.ory.localhost/auth/login
 
     login:
       ui_url: http://auth.ory.localhost/auth/login

--- a/config/kratos/kratos.production.yml
+++ b/config/kratos/kratos.production.yml
@@ -44,6 +44,11 @@ selfservice:
     - https://admin.cativo.dev
     - https://admin.cativo.dev/dashboard
     - https://api.cativo.dev
+    # The app is the neutral DEFAULT_RETURN_URL target (VITE_DEFAULT_RETURN_URL in
+    # the prod build); Kratos validates return_to against this list, so the app
+    # host must be allowed or context-less flows would 400.
+    - https://app.cativo.dev
+    - https://app.cativo.dev/
 
   methods:
     password:

--- a/config/kratos/kratos.production.yml
+++ b/config/kratos/kratos.production.yml
@@ -35,7 +35,10 @@ serve:
     base_url: http://kratos:4434/
 
 selfservice:
-  default_browser_return_url: https://admin.cativo.dev/dashboard
+  # Neutral fallback for flows that complete WITHOUT a return_to (multi-app IdP:
+  # admin/dashboard is the wrong default — most users aren't admins). Per-flow
+  # return_to / after_verification_return_to override this when context exists.
+  default_browser_return_url: https://auth.cativo.dev/auth/login
   allowed_return_urls:
     - https://auth.cativo.dev
     - https://admin.cativo.dev
@@ -68,11 +71,14 @@ selfservice:
       ui_url: https://auth.cativo.dev/auth/verification
       use: code
       after:
-        default_browser_return_url: https://admin.cativo.dev/dashboard
+        # Neutral fallback when the verification flow has no return_to /
+        # after_verification_return_to (e.g. an app user clicking the email link
+        # without context). Was admin/dashboard → wrongly dumped app users in admin.
+        default_browser_return_url: https://auth.cativo.dev/auth/login
 
     logout:
       after:
-        default_browser_return_url: https://admin.cativo.dev/
+        default_browser_return_url: https://auth.cativo.dev/auth/login
 
     login:
       ui_url: https://auth.cativo.dev/auth/login

--- a/frontend-auth/src/composables/useAuth.ts
+++ b/frontend-auth/src/composables/useAuth.ts
@@ -75,12 +75,18 @@ export async function getRegistrationFlow(flowId: string): Promise<RegistrationF
   return data
 }
 
-// `returnTo` is accepted for call-site compatibility but Kratos browser
-// registration here does not forward it (parity with the prior JS behavior,
-// where the argument was silently ignored).
-export async function createRegistrationFlow(_returnTo: string | null = null): Promise<RegistrationFlow> {
-  void _returnTo
-  const { data } = await ory.createBrowserRegistrationFlow()
+// Forward `returnTo` so registration completion returns the user to the
+// originating app, and `afterVerificationReturnTo` so the verification flow
+// spawned by the registration after-hook (the email-link path) ALSO lands back
+// on that app instead of falling through to the global default. Both are
+// documented Kratos registration-init parameters; without them an app user who
+// verifies via the email link is dumped on `default_browser_return_url`.
+export async function createRegistrationFlow(returnTo: string | null = null): Promise<RegistrationFlow> {
+  const { data } = await ory.createBrowserRegistrationFlow(
+    returnTo
+      ? { returnTo, afterVerificationReturnTo: returnTo }
+      : {},
+  )
   return data
 }
 

--- a/frontend-auth/src/utils/defaultReturnUrl.ts
+++ b/frontend-auth/src/utils/defaultReturnUrl.ts
@@ -1,0 +1,18 @@
+/**
+ * DEFAULT_RETURN_URL — last-resort fallback for self-service flows that complete
+ * WITHOUT a return_to / login_challenge (i.e. no originating-app context).
+ *
+ * Per OAuth 2.0 / OIDC best practice the destination after authentication is
+ * provided by the *originating app* (the validated OAuth `redirect_uri` for
+ * third-party clients, or a `return_to` for first-party SPAs) — the IdP must NOT
+ * hardcode a specific app, least of all a privileged console like the admin
+ * dashboard. Sending a context-less user to admin is what made app users land in
+ * the admin console after verifying via the email link.
+ *
+ * This constant is therefore the neutral fallback used ONLY when no context
+ * exists. It defaults to the app (the product surface), not admin, and is
+ * overridable via VITE_DEFAULT_RETURN_URL. When real context is present the
+ * flows use it instead of this value.
+ */
+export const DEFAULT_RETURN_URL =
+  import.meta.env.VITE_DEFAULT_RETURN_URL || 'http://app.ory.localhost'

--- a/frontend-auth/src/views/Login.vue
+++ b/frontend-auth/src/views/Login.vue
@@ -240,6 +240,7 @@ import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
 import { safeRedirect } from '../utils/safeRedirect'
+import { DEFAULT_RETURN_URL } from '../utils/defaultReturnUrl'
 
 const refreshAuth = inject<(() => Promise<void>) | null>('refreshAuth', null)
 import {
@@ -284,10 +285,9 @@ onMounted(async () => {
       intendedReturnUrl.value = returnUrl
       flow.value = await createLoginFlow(returnUrl)
     } else {
-      // Use return_to if provided, otherwise default to admin dashboard
-      const authUrl = import.meta.env.VITE_AUTH_URL || window.location.origin
-      const adminUrl = import.meta.env.VITE_ADMIN_URL || 'http://admin.ory.localhost'
-      const returnUrl = returnTo || `${adminUrl}/dashboard`
+      // No app context (no flow, no login_challenge, no return_to): fall back to
+      // the neutral default — NOT a hardcoded admin console.
+      const returnUrl = returnTo || DEFAULT_RETURN_URL
       flow.value = await createLoginFlow(returnUrl)
     }
   } catch (error) {
@@ -448,8 +448,7 @@ const handleSubmit = async (event: Event) => {
       // Prefer intended return URL (OAuth hydra-callback), then flow/query
       const returnTo = intendedReturnUrl.value || flow.value?.return_to || firstQuery(route.query.return_to) || firstQuery(route.query.returnTo)
 
-      const adminUrl = import.meta.env.VITE_ADMIN_URL || 'http://admin.ory.localhost'
-      const destination = safeRedirect(returnTo ? decodeURIComponent(returnTo) : null, `${adminUrl}/dashboard`)
+      const destination = safeRedirect(returnTo ? decodeURIComponent(returnTo) : null, DEFAULT_RETURN_URL)
       window.location.href = destination
     } else {
       // Response has errors: check for verification required (continue_with in success body)

--- a/frontend-auth/src/views/Verification.vue
+++ b/frontend-auth/src/views/Verification.vue
@@ -266,6 +266,7 @@ import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
 import { safeRedirect } from '../utils/safeRedirect'
+import { DEFAULT_RETURN_URL } from '../utils/defaultReturnUrl'
 import {
   getNodeValue,
   getNodeName,
@@ -278,7 +279,8 @@ import {
 } from '../utils/uiNodes'
 
 const RESEND_COOLDOWN_SEC = 60
-const DEFAULT_AFTER_VERIFICATION = (import.meta.env.VITE_ADMIN_URL || 'http://admin.ory.localhost') + '/dashboard'
+// Neutral fallback only — real context (return_to) takes precedence below. Not admin.
+const DEFAULT_AFTER_VERIFICATION = DEFAULT_RETURN_URL
 
 /** Kratos query params may be string | string[] | null — normalize to a single string. */
 function firstQuery(v: LocationQueryValue | LocationQueryValue[] | undefined): string | undefined {


### PR DESCRIPTION
## Bug
Creating an account from **app.ory** → verification email → clicking the link → completing verification landed the user on the **admin console** ("me intenta loguear al admin").

## Root cause (reproduced)
1. `frontend-auth` `createRegistrationFlow()` **discarded its `returnTo`** (`void _returnTo`, then `createBrowserRegistrationFlow()` with no args) on a wrong assumption that Kratos ignores it. Kratos honors both `return_to` and `after_verification_return_to`.
2. Kratos `default_browser_return_url` (global + `verification.after` + `logout.after`) all pointed at `admin/dashboard` — the wrong fallback for a multi-app IdP. Any flow without a `return_to` (the email-link verification path) fell through to admin.

## Fix (two layers)
- **Frontend:** `createRegistrationFlow` now forwards `returnTo` **and** `afterVerificationReturnTo` (documented Kratos registration-init params) so the verification flow spawned by the after-hook lands back on the originating app.
- **Config:** neutralized the admin-centric defaults → auth login page (local + prod parity). Per-flow `return_to`/`after_verification_return_to` still override when context exists.

## Verified (API repro)
- No context → redirect `http://auth.ory.localhost/auth/login` (was admin/dashboard) ✅
- With app `return_to`+`after_verification_return_to` → redirect `http://app.ory.localhost/dashboard` ✅
- Net: never admin again — with context → app, without → neutral auth login.

Validated against Ory docs (`after_verification_return_to` is the documented mechanism; precedence global < per-flow < per-method < return_to). Final real-browser email-link click-through still worth a manual smoke.