### PR TITLE
fix(audit): apply PR #41 review fixes (idempotent migration, gen_random_uuid)

### DIFF
--- a/api/src/audit/audit.datasource.ts
+++ b/api/src/audit/audit.datasource.ts
@@ -7,18 +7,19 @@ import { AuditLog } from './audit-log.entity';
  * migration:run, migration:revert). It is NOT imported by the NestJS app module
  * — the app uses TypeOrmModule.forRoot() in AuditModule.
  *
- * Connection parameters mirror audit.module.ts exactly: all read from the same
- * AUDIT_DB_* environment variables so the same .env file drives both paths.
+ * Connection parameters mirror audit.module.ts exactly: same AUDIT_DB_* env vars,
+ * same lack of silent defaults (fail fast on a missing var rather than connect to
+ * a stray localhost/postgres DB and generate a migration against the wrong schema).
  *
  * Required export name: "default" — TypeORM CLI requires a default export.
  */
 const AuditDataSource = new DataSource({
   type: 'postgres',
-  host: process.env.AUDIT_DB_HOST ?? 'localhost',
+  host: process.env.AUDIT_DB_HOST,
   port: parseInt(process.env.AUDIT_DB_PORT ?? '5432', 10),
-  username: process.env.AUDIT_DB_USER ?? 'postgres',
+  username: process.env.AUDIT_DB_USER,
   password: process.env.AUDIT_DB_PASSWORD,
-  database: process.env.AUDIT_DB_NAME ?? 'nova_audit',
+  database: process.env.AUDIT_DB_NAME,
   entities: [AuditLog],
   migrations: ['src/audit/migrations/*.ts'],
   /**

--- a/api/src/audit/migrations/1781750293893-CreateAuditLogs.ts
+++ b/api/src/audit/migrations/1781750293893-CreateAuditLogs.ts
@@ -4,9 +4,15 @@ export class CreateAuditLogs1781750293893 implements MigrationInterface {
     name = 'CreateAuditLogs1781750293893'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "audit_logs" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "actorId" character varying NOT NULL, "actorEmail" character varying, "action" character varying NOT NULL, "appId" character varying, "targetId" character varying, "targetType" character varying, "metadata" jsonb, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1bb179d048bbc581caa3b013439" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_2dc33f7f3c22e2e7badafca1d1" ON "audit_logs" ("actorId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_cee5459245f652b75eb2759b4c" ON "audit_logs" ("action") `);
+        // gen_random_uuid() is in PostgreSQL core (13+); avoids depending on the
+        // uuid-ossp extension (which needs superuser to CREATE and is not enabled
+        // by default — uuid_generate_v4() would fail on a fresh DB). IF NOT EXISTS
+        // makes this initial migration idempotent so migrationsRun does not crash
+        // on environments where audit_logs already exists from the prior
+        // synchronize-based path (boots before migrations were introduced).
+        await queryRunner.query(`CREATE TABLE IF NOT EXISTS "audit_logs" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "actorId" character varying NOT NULL, "actorEmail" character varying, "action" character varying NOT NULL, "appId" character varying, "targetId" character varying, "targetType" character varying, "metadata" jsonb, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1bb179d048bbc581caa3b013439" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_2dc33f7f3c22e2e7badafca1d1" ON "audit_logs" ("actorId") `);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_cee5459245f652b75eb2759b4c" ON "audit_logs" ("action") `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
Follow-up to #41: the review-fix commit didn't reach origin before #41 was squash-merged, so develop landed the unfixed version. This re-applies the validated fixes:

- **B-2 (real blocker):** `CREATE TABLE/INDEX IF NOT EXISTS` so `migrationsRun` doesn't crash on envs where `audit_logs` already exists from the pre-migration synchronize path. Verified idempotent in-DB.
- **B-1 (hardening):** `gen_random_uuid()` (PG core 13+) instead of `uuid_generate_v4()` — column default no longer depends on the uuid-ossp extension. Verified on a fresh DB (extension dropped) the migration runs and inserts auto-generate ids. (Note: TypeORM also auto-creates uuid-ossp, so the original wasn't a hard failure here — this removes the implicit dependency.)
- **W-1:** drop silent `localhost/postgres/nova_audit` defaults in the standalone DataSource so it fails fast (matches the module).

85/85 BFF tests pass; typecheck clean; migration verified end-to-end against nova_audit.