### PR TITLE
ci: add pipeline + ADR-0001 boundary gate, bump node to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+# Mechanical gates that must pass before code lands on develop/main. Without this
+# the project's quality scripts (typecheck, jest, openapi:verify, ADR-0001 boundary
+# check) are dead letters — present but never enforced. See ADR-0001 for why the
+# IdP/demo boundary is enforced by tooling rather than developer discipline.
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # pnpm workspace: the generated api-client + the three Vue SPAs.
+  # `api/` is NOT a workspace member (it uses npm) — it has its own job below.
+  # ---------------------------------------------------------------------------
+  workspace:
+    name: Workspace (typecheck + build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # frontend-auth and frontend-admin import @nova-id/api-client, whose generated
+      # sources are gitignored (regenerated from api/openapi.json). Generate them
+      # before typecheck/build so those imports resolve. api/openapi.json is committed.
+      - name: Generate API client
+        run: pnpm run client:gen
+
+      - name: Typecheck (api-client + all SPAs)
+        run: pnpm -r run typecheck
+
+      - name: Build SPAs
+        run: pnpm -r run build
+
+  # ---------------------------------------------------------------------------
+  # NestJS BFF (api/) — standalone npm project, not part of the pnpm workspace.
+  # ---------------------------------------------------------------------------
+  api:
+    name: API (build + test + boundary)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nova_audit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      AUDIT_DB_HOST: localhost
+      AUDIT_DB_PORT: "5432"
+      AUDIT_DB_USER: postgres
+      AUDIT_DB_PASSWORD: postgres
+      AUDIT_DB_NAME: nova_audit
+    defaults:
+      run:
+        working-directory: ./api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Unit tests fully mock the audit repository so they run without a live DB.
+      # The Postgres service above is required by openapi:verify (NestFactory boots
+      # AppModule → AuditModule → TypeORM forRoot with migrationsRun: true).
+      - name: Test
+        run: npm test
+
+      # Fails if the committed openapi.json drifts from the decorated controllers.
+      - name: Verify OpenAPI is up to date
+        run: npm run openapi:verify
+
+      # Enforces the ADR-0001 one-way module boundary (IdP must not import demo).
+      - name: Check module boundary (ADR-0001)
+        run: npm run boundary:check

--- a/api/.dependency-cruiser.js
+++ b/api/.dependency-cruiser.js
@@ -1,0 +1,45 @@
+/**
+ * dependency-cruiser configuration — enforces the ADR-0001 internal module boundary.
+ *
+ * ADR-0001 ("Separate the demo-app backend from the IdP BFF via a hard internal
+ * module boundary") mandates a ONE-WAY dependency arrow: DemoModule -> IdP, never
+ * IdP -> DemoModule. The IdP modules (admin/, me/, ory/, auth/) must not import any
+ * symbol from the quarantined demo code under src/demo/.
+ *
+ * This rule is the mechanical enforcement the ADR calls for ("to enforce architecture
+ * we should use the computer as much as possible and treat code-review as the last
+ * line of defense"). It fails the build the moment an IdP module imports demo code,
+ * making the violation impossible to merge rather than merely discouraged.
+ *
+ * Run via `npm run boundary:check` (depcruise src --config .dependency-cruiser.js),
+ * from the api/ directory, so module paths are rooted at `src/`.
+ */
+module.exports = {
+  forbidden: [
+    {
+      name: 'idp-must-not-import-demo',
+      comment:
+        'ADR-0001: IdP modules (admin/me/ory/auth) must not depend on the demo app ' +
+        '(src/demo). The dependency arrow is one-way: DemoModule -> IdP only.',
+      severity: 'error',
+      from: { path: '^src/(admin|me|ory|auth)/' },
+      to: { path: '^src/demo/' },
+    },
+    {
+      name: 'no-circular',
+      comment: 'Circular dependencies make the module graph impossible to reason about.',
+      severity: 'warn',
+      from: {},
+      to: { circular: true },
+    },
+  ],
+  options: {
+    doNotFollow: { path: 'node_modules' },
+    tsPreCompilationDeps: true,
+    tsConfig: { fileName: 'tsconfig.json' },
+    enhancedResolveOptions: {
+      exportsFields: ['exports'],
+      conditionNames: ['import', 'require', 'node', 'default'],
+    },
+  },
+};

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ COPY src ./src
 RUN npm run build
 
 # Production stage
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -44,6 +44,7 @@
         "@types/supertest": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^6.17.0",
         "@typescript-eslint/parser": "^6.17.0",
+        "dependency-cruiser": "^16.10.4",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.2",
@@ -3048,6 +3049,26 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -4623,6 +4644,98 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dependency-cruiser": {
+      "version": "16.10.4",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-16.10.4.tgz",
+      "integrity": "sha512-hrxVOjIm8idZ9ZVDGSyyG3SHiNcEUPhL6RTEmO/3wfQWLepH5pA3nuDMMrcJ1DkZztFA7xg3tk8OVO+MmwwH9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "acorn-jsx-walk": "^2.0.0",
+        "acorn-loose": "^8.5.2",
+        "acorn-walk": "^8.3.4",
+        "ajv": "^8.17.1",
+        "commander": "^13.1.0",
+        "enhanced-resolve": "^5.18.2",
+        "ignore": "^7.0.5",
+        "interpret": "^3.1.1",
+        "is-installed-globally": "^1.0.0",
+        "json5": "^2.2.3",
+        "memoize": "^10.1.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "prompts": "^2.4.2",
+        "rechoir": "^0.8.0",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.7.2",
+        "teamcity-service-messages": "^0.1.14",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
+        "watskeburt": "^4.2.3"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^18.17||>=20"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -5448,6 +5561,23 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6047,6 +6177,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -6468,6 +6624,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -6575,6 +6741,36 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -8027,6 +8223,22 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
+      "integrity": "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -8130,6 +8342,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -9535,11 +9760,34 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -9801,6 +10049,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -10699,6 +10957,13 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/teamcity-service-messages": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/teamcity-service-messages/-/teamcity-service-messages-0.1.14.tgz",
+      "integrity": "sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/terser": {
       "version": "5.46.0",
@@ -11671,6 +11936,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.2.3.tgz",
+      "integrity": "sha512-uG9qtQYoHqAsnT711nG5iZc/8M5inSmkGCOp7pFaytKG2aTfIca7p//CjiVzAE4P7hzaYuCozMjNNaLgmhbK5g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^18||>=20"
       }
     },
     "node_modules/wcwidth": {

--- a/api/package.json
+++ b/api/package.json
@@ -20,10 +20,14 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "openapi:gen": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
     "openapi:verify": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts && git diff --exit-code -- openapi.json",
+    "boundary:check": "depcruise src --config .dependency-cruiser.js",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/audit/audit.datasource.ts",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d src/audit/audit.datasource.ts",
     "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/audit/audit.datasource.ts",
     "migration:show": "typeorm-ts-node-commonjs migration:show -d src/audit/audit.datasource.ts"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "dependencies": {
     "@nestjs/common": "^10.3.0",
@@ -61,6 +65,7 @@
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
+    "dependency-cruiser": "^16.10.4",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.2",

--- a/frontend-app/src/composables/useApiTest.ts
+++ b/frontend-app/src/composables/useApiTest.ts
@@ -2,6 +2,11 @@
  * Base URL for the Test API (Oathkeeper rule: /api-test -> api:8080).
  * Use this for all calls to the test API: /me, /logs, /roles/*, etc.
  * Do NOT use getOathkeeperUrl() for these - that is for Kratos/Hydra paths under /api.
+ *
+ * Note: frontend-app intentionally does NOT consume the generated @nova-id/api-client.
+ * That client is generated from the IdP's OpenAPI (the /api surface). frontend-app is
+ * the demo app and talks only to the demo-only /api-test/* endpoints (ADR-0001 boundary),
+ * so it calls them directly with fetch rather than pulling in the IdP client.
  */
 export function getApiTestBaseUrl() {
   const env = import.meta.env.VITE_API_TEST_URL

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "packageManager": "pnpm@11.0.0",
-  "engines": { "node": ">=18" },
+  "engines": { "node": ">=22" },
   "scripts": {
     "client:gen": "pnpm --filter @nova-id/api-client run generate",
     "typecheck": "pnpm -r run typecheck"


### PR DESCRIPTION
## What

Establishes CI for the monorepo, closing the dead-letter quality gates (code-review finding **B-1**): the repo had `typecheck`, `jest`, `openapi:verify` and an ADR-0001 boundary rule available as scripts, but nothing ran them.

## Findings addressed

- **B-1** — `.github/workflows/ci.yml` with two jobs gating every push/PR to `develop`/`main`:
  - **workspace** (pnpm, node 22): `install --frozen-lockfile` → `client:gen` → `pnpm -r run typecheck` → `pnpm -r run build`.
  - **api** (npm, node 22): `npm ci` → build → test → `openapi:verify` → `boundary:check`. Includes a `postgres:16-alpine` service (gated by `pg_isready` health check) because `openapi:verify` boots `AppModule → AuditModule` (`migrationsRun: true`).
- **B-2** — `api/.dependency-cruiser.js` encodes `idp-must-not-import-demo` (ADR-0001 one-way `IdP → demo` boundary) + `boundary:check` script + devDep. Validated: passes clean, fails on an injected `IdP → demo` import.
- **B-4** — bump node `18 → 22` in `api/Dockerfile` (builder + prod), `api/Dockerfile.dev`, and `engines.node` in root + api `package.json`.
- **B-5** — comment documenting that `frontend-app` intentionally omits `@nova-id/api-client` (demo-only `/api-test/*`, ADR-0001).

## Validation

- api job steps run locally (containerized): build ✓, jest 85/85 ✓, openapi no-drift ✓, boundary:check ✓.
- workspace job steps: `client:gen` ✓, typecheck ✓, build (3 SPAs) ✓.
- Code review: 0 blockers / 0 warnings / 0 nits.