### PR TITLE
ci: fix workspace install + api openapi boot in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
       HYDRA_ADMIN_URL: http://localhost:4445
       KETO_READ_URL: http://localhost:4466
       KRATOS_ADMIN_URL: http://localhost:4434
+      # AuthenticatedGuard reads these via ConfigService.getOrThrow at boot
+      # (api/src/guards/authenticated.guard.ts). The JwksClient is lazy — no
+      # network call is made during generation — so placeholder URLs suffice.
+      OAUTH_JWKS_URL: http://localhost:4456/.well-known/jwks.json
+      OAUTH_ISSUER: http://localhost:4455/
     defaults:
       run:
         working-directory: ./api
@@ -107,6 +112,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # DemoModule's SQLite DB lives in api/data/ which is gitignored and therefore
+      # absent on a fresh checkout. sqlite3 won't create the parent directory itself,
+      # so we pre-create it here to prevent a boot-time SQLITE_CANTOPEN error.
+      - name: Create demo SQLite data dir
+        run: mkdir -p data
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,15 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # dangerouslyAllowAllBuilds: pnpm 11 fails install (ERR_PNPM_IGNORED_BUILDS,
+      # exit 1) whenever a dependency has an ignored build script. The pnpm-workspace
+      # `onlyBuiltDependencies` allowlist does NOT suppress this gate on a fresh
+      # frozen install (verified on pnpm 11.0.0 and 11.8.0). The only build-script
+      # deps in the locked tree are esbuild (vite's native binary — required for the
+      # SPA builds below) and vue-demi; with a frozen lockfile, allowing all builds
+      # means exactly those trusted, pinned packages.
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --config.dangerouslyAllowAllBuilds=true
 
       # frontend-auth and frontend-admin import @nova-id/api-client, whose generated
       # sources are gitignored (regenerated from api/openapi.json). Generate them
@@ -77,6 +84,14 @@ jobs:
       AUDIT_DB_USER: postgres
       AUDIT_DB_PASSWORD: postgres
       AUDIT_DB_NAME: nova_audit
+      # openapi:verify boots the full AppModule. OryModule's providers resolve these
+      # via ConfigService.getOrThrow at boot (api/src/ory/ory.module.ts), so they must
+      # exist or the app crashes before the spec is generated. The values are never
+      # dialed — OpenAPI generation only reads decorator metadata, it makes no Ory
+      # calls — so placeholder URLs are sufficient.
+      HYDRA_ADMIN_URL: http://localhost:4445
+      KETO_READ_URL: http://localhost:4466
+      KRATOS_ADMIN_URL: http://localhost:4434
     defaults:
       run:
         working-directory: ./api

--- a/api/scripts/generate-openapi.ts
+++ b/api/scripts/generate-openapi.ts
@@ -36,5 +36,8 @@ async function generate() {
 
 generate().catch((err) => {
   console.error('OpenAPI generation failed:', err);
-  process.exit(1);
+  // Set the exit code rather than calling process.exit(1): a synchronous
+  // process.exit truncates buffered stderr, which hid the real boot error in CI.
+  // Letting the event loop drain flushes the message before the process exits.
+  process.exitCode = 1;
 });


### PR DESCRIPTION
Follow-up to #45. The first CI run on `develop` failed **both** jobs; each root cause was reproduced in a clean node:22 environment before fixing.

## workspace job — `pnpm install --frozen-lockfile`
`ERR_PNPM_IGNORED_BUILDS` (exit 1): pnpm 11 aborts install on any ignored build script. The `pnpm-workspace` `onlyBuiltDependencies` allowlist does **not** suppress this gate on a fresh frozen install (verified on pnpm 11.0.0 **and** 11.8.0; also tried the `package.json` `pnpm` field). Fix: `--config.dangerouslyAllowAllBuilds=true`. With a frozen lockfile the only build-script deps are `esbuild` (vite's native binary, required for the SPA builds) and `vue-demi` — both pinned and trusted. Verified clean install exits 0 and the esbuild binary is present.

## api job — `npm run openapi:verify`
Failed in ~2s with no output. `generate-openapi.ts` boots the full `AppModule`; `OryModule` resolves `HYDRA_ADMIN_URL` / `KETO_READ_URL` / `KRATOS_ADMIN_URL` via `ConfigService.getOrThrow` at boot (`api/src/ory/ory.module.ts`). The job only set `AUDIT_DB_*`, so boot threw — and the error was swallowed by `process.exit(1)` in the generator's `catch`. Fix: add placeholder Ory URLs to the job env. Generation reads decorator metadata only and never dials Ory.

Also confirmed: the node-22-generated `openapi.json` is **byte-identical** to the committed one (no node-version drift) and the audit migration runs clean on a fresh `postgres:16` DB.