### PR TITLE
feat(authz): Mode-A gateway Keto gate on admin surface + demo route cleanup

### DIFF
--- a/api/src/demo/demo.controller.ts
+++ b/api/src/demo/demo.controller.ts
@@ -108,13 +108,13 @@ export class DemoController {
     return this.demoService.configureAppAdmin(user, dto);
   }
 
-  @Put(':id')
+  @Put('data/:id')
   @UseGuards(AppUserGuard)
   updateData(@GetUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: DemoUpdateDataDto) {
     return this.demoService.updateData(user, id, dto);
   }
 
-  @Delete(':id')
+  @Delete('data/:id')
   @UseGuards(AppUserGuard)
   deleteData(@GetUser() user: AuthenticatedUser, @Param('id') id: string) {
     return this.demoService.deleteData(user, id);

--- a/config/oathkeeper/rules.local.json
+++ b/config/oathkeeper/rules.local.json
@@ -453,14 +453,14 @@
     ]
   },
   {
-    "id": "protected-api",
+    "id": "me-permissions",
     "upstream": {
       "preserve_host": true,
       "strip_path": "/api",
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/v1/(me/permissions|admin(?!-))(/.*)?>",
+      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/v1/me/permissions(/.*)?>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [
@@ -479,6 +479,45 @@
     ],
     "authorizer": {
       "handler": "allow"
+    },
+    "mutators": [
+      {
+        "handler": "id_token"
+      }
+    ]
+  },
+  {
+    "id": "protected-admin",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api",
+      "url": "http://api:8080"
+    },
+    "match": {
+      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/v1/admin(?!-)(/.*)?>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    },
+    "authenticators": [
+      {
+        "handler": "cookie_session",
+        "config": {
+          "check_session_url": "http://kratos:4433/sessions/whoami",
+          "preserve_path": true,
+          "extra_from": "@this",
+          "subject_from": "identity.id"
+        }
+      },
+      {
+        "handler": "oauth2_introspection"
+      }
+    ],
+    "authorizer": {
+      "handler": "remote_json",
+      "config": {
+        "remote": "http://keto:4466/relation-tuples/check",
+        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"administer\",\"subject_id\":\"user:{{ print .Subject }}\"}",
+        "forward_response_headers_to_upstream": ["Content-Type"]
+      }
     },
     "mutators": [
       {

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -235,14 +235,14 @@
     ]
   },
   {
-    "id": "protected-api",
+    "id": "me-permissions",
     "upstream": {
       "preserve_host": true,
       "strip_path": "/api",
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(me/permissions|admin(?!-))(/.*)?>",
+      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/me/permissions(/.*)?>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [
@@ -261,6 +261,43 @@
     ],
     "authorizer": {
       "handler": "allow"
+    },
+    "mutators": [
+      { "handler": "id_token" }
+    ]
+  },
+  {
+    "id": "protected-admin",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api",
+      "url": "http://api:8080"
+    },
+    "match": {
+      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/admin(?!-)(/.*)?>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    },
+    "authenticators": [
+      {
+        "handler": "cookie_session",
+        "config": {
+          "check_session_url": "http://kratos:4433/sessions/whoami",
+          "preserve_path": true,
+          "extra_from": "@this",
+          "subject_from": "identity.id"
+        }
+      },
+      {
+        "handler": "oauth2_introspection"
+      }
+    ],
+    "authorizer": {
+      "handler": "remote_json",
+      "config": {
+        "remote": "http://keto:4466/relation-tuples/check",
+        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"administer\",\"subject_id\":\"user:{{ print .Subject }}\"}",
+        "forward_response_headers_to_upstream": ["Content-Type"]
+      }
     },
     "mutators": [
       { "handler": "id_token" }

--- a/frontend-admin/src/composables/usePermissions.ts
+++ b/frontend-admin/src/composables/usePermissions.ts
@@ -1,4 +1,4 @@
-// Permissions helper — reads from BFF /api/me/permissions (A1.3+).
+// Permissions helper — reads from BFF /api/v1/me/permissions (A1.3+).
 // Keto is no longer called directly from the frontend; all permission logic
 // is server-side in the BFF (KetoService).
 //


### PR DESCRIPTION
Closes the last open code-review items: **(c) Mode-A gateway PEP gap (ADR-0004)**, **M-7**, and **L-BFF catch-all routes**.

## (c) Mode-A — gateway Keto gate on the admin surface
ADR-0004 commits to dual-mode enforcement (gateway PEP→PDP **and** BFF guard). The `protected-api` rule used `authorizer: allow` for both `/api/v1/me/permissions` and `/api/v1/admin/*`, so the per-request Keto check on the admin surface lived only in the in-process `PlatformManageUsersGuard` — not the double enforcement the ADR promises.

Split `protected-api` into two rules (in **both** `rules.local.json` and `rules.production.json`):
- **`me-permissions`** → `/api/v1/me/permissions`, `authorizer: allow` — self-scoped; any authenticated user reads their *own* permissions, so it must **not** be admin-gated.
- **`protected-admin`** → `/api/v1/admin(?!-)`, `authorizer: remote_json` checking `Platform:nova#administer` — consistent with every other gateway Platform gate (`hydra-admin`, `keto-read/write`, `frontend-admin`, `api-roles-bootstrap`).

The BFF `PlatformManageUsersGuard` (checks `manage_users`) stays as defense-in-depth. `administer` and `manage_users` are OPL-equivalent today (both derive from `Platform:nova#admins`); keeping the two layers on different permits is intentional defense-in-depth.

**Validated against the live stack (6/6 PASS):**
| Route | no session | non-admin | admin |
|---|---|---|---|
| `/api/v1/admin/users` | 401 | **403** | **200** |
| `/api/v1/me/permissions` | 401 | **200** | 200 |

## M-7 (turned out near-false-positive)
The claimed 404s aren't real: `/api/v1/me/permissions` is matched by the rule; `/api/v1/admin-demo` isn't a versioned route (the demo endpoint is served via `/api-test/admin-demo`). The only artifact was a **stale comment** in `usePermissions.ts` referencing `/api/me/permissions` — corrected to `/api/v1/me/permissions`.

## L-BFF — demo catch-all routes
`DemoController` `@Put(':id')`/`@Delete(':id')` (no controller path prefix) resolved to a root-level catch-all `PUT/DELETE /api-test/<anything>`. Scoped to `/api-test/data/:id`. No caller used the bare form; the Oathkeeper `api-test` rule still covers it. api tests green (85/85).