### PR TITLE
build: production runtime hardening (Bucket-B / B1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,7 +57,7 @@ KETO_READ_URL=http://keto:4466
 
 # API: JWT validation (Oathkeeper id_token mutator)
 # OAUTH_ISSUER MUST match the id_token issuer_url in config/oathkeeper/oathkeeper.${ENVIRONMENT}.yml.
-# Production: OAUTH_ISSUER=https://api.cativo.dev/  (must equal oathkeeper.production.yml id_token issuer_url)
+# Production: OAUTH_ISSUER=https://id.cativo.dev/  (must equal oathkeeper.production.yml id_token issuer_url)
 OAUTH_ISSUER=http://api.local/
 # OAUTH_JWKS_URL: REQUIRED. Oathkeeper's JWKS API endpoint. Oathkeeper mints an
 # RS256 id_token (Bearer JWT) for authenticated requests and publishes its public
@@ -74,7 +74,7 @@ KRATOS_BROWSER_URL=http://auth.local
 ADMIN_URL=http://admin.local
 
 # URLs - Production (uncomment and set for production)
-# API_URL=https://api.cativo.dev
+# API_URL=https://id.cativo.dev
 # KRATOS_BROWSER_URL=https://auth.cativo.dev
 # ADMIN_URL=https://admin.cativo.dev
 

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,54 @@
+# Nova ID — PRODUCTION environment template
+# ---------------------------------------------------------------------------
+# Copy to `.env.production` ON THE SERVER (polaris2) and fill with REAL secrets.
+#   cp .env.production.example .env.production && chmod 600 .env.production
+# NEVER commit `.env.production` — it is gitignored. This *.example file carries
+# NO secrets and IS committed as documentation.
+#
+# Generate every secret freshly for production (do NOT reuse dev values):
+#   openssl rand -base64 32                      # general secrets / passwords
+#   openssl rand -base64 32 | tr -d '=/+' | cut -c1-32   # exactly-32-char (cipher)
+#
+# Consumed by: docker-compose.production.yml (Postgres + Ory services) and the
+# NestJS API (via env_file). Used as: docker compose -f docker-compose.production.yml up -d
+# ---------------------------------------------------------------------------
+
+# ---- Database passwords (per-service users created by postgres-init) ----
+POSTGRES_PASSWORD=__GENERATE__
+ORY_PASSWORD=__GENERATE__
+KRATOS_DB_PASSWORD=__GENERATE__
+HYDRA_DB_PASSWORD=__GENERATE__
+KETO_DB_PASSWORD=__GENERATE__
+
+# ---- Kratos secrets (Ory path-mapped → SECRETS_COOKIE/CIPHER/DEFAULT) ----
+# cookie:  >=16 chars   cipher: EXACTLY 32 chars   default: >=16 chars
+KRATOS_SECRETS_COOKIE=__GENERATE__
+KRATOS_SECRETS_CIPHER=__GENERATE_EXACTLY_32_CHARS__
+KRATOS_SECRETS_DEFAULT=__GENERATE__
+
+# ---- Hydra system secret (Ory path-mapped → SECRETS_SYSTEM) ----
+HYDRA_SYSTEM_SECRET=__GENERATE__
+
+# ---- OAuth / JWT (API validates Oathkeeper-minted id_tokens) ----
+# OAUTH_ISSUER MUST byte-for-byte equal `issuer_url` in
+# config/oathkeeper/oathkeeper.production.yml (trailing slash included).
+OAUTH_ISSUER=https://id.cativo.dev/
+# Internal Docker URL — Oathkeeper publishes its signing public key here.
+OAUTH_JWKS_URL=http://oathkeeper:4456/.well-known/jwks.json
+
+# ---- SMTP (Kratos courier: verification / recovery email) ----
+# Provider: Resend (reuse the API key already provisioned for the Ghost blog on
+# polaris2). Format: smtps://resend:<RESEND_API_KEY>@smtp.resend.com:465/
+SMTP_CONNECTION_URI=smtps://resend:__RESEND_API_KEY__@smtp.resend.com:465/
+SMTP_FROM_ADDRESS=noreply@cativo.dev
+
+# ---------------------------------------------------------------------------
+# Notes
+# - JWKS signing key: generate a FRESH production key on the server and mount it
+#   at config/oathkeeper/id_token.jwks.json (gitignored). Never reuse the dead
+#   dev key. See docs/SECURITY_KEY_ROTATION.md.
+# - Audit DB: the API connects to nova_audit as the postgres superuser by default
+#   (AUDIT_DB_* are set in docker-compose.production.yml). Production hardening:
+#   provision a dedicated audit_user with INSERT-only grants on audit_logs and
+#   override AUDIT_DB_USER/AUDIT_DB_PASSWORD here.
+# ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,25 @@ jobs:
       # Enforces the ADR-0001 one-way module boundary (IdP must not import demo).
       - name: Check module boundary (ADR-0001)
         run: npm run boundary:check
+
+  # ---------------------------------------------------------------------------
+  # Production Docker image build — verifies all three production Dockerfiles
+  # compile successfully. Build-only: no images are pushed or deployed.
+  # Trivy scan omitted: no registry push in CI, so scanning build-time artifacts
+  # adds runtime cost without actionable signal until B3 (CD) lands.
+  # ---------------------------------------------------------------------------
+  build-prod-images:
+    name: Build production images (build-only, no push)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Validate the compose file is syntactically valid before attempting the build.
+      - name: Validate docker-compose.production.yml
+        run: docker compose -f docker-compose.production.yml config >/dev/null
+
+      # Build api (api/Dockerfile) + frontend-auth + frontend-admin
+      # (Dockerfile.frontend.prod with VITE build args). Runtime env_file entries
+      # are irrelevant to `build`; build args are declared inline in the compose file.
+      - name: Build production images
+        run: docker compose -f docker-compose.production.yml build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # docker-compose.production.yml declares `env_file: [.env.production]` on every
+      # Ory service, and Compose v2 hard-errors when an env_file is missing. That file
+      # is gitignored (real secrets), so it's absent in CI. Build args (VITE_*) are
+      # literal in the compose file and env_file values are NOT used during `build`,
+      # so a placeholder stub from the committed template satisfies the existence check.
+      # env_file stays REQUIRED (not required:false) so production fails loudly on missing secrets.
+      - name: Stub .env.production for build (values irrelevant to build)
+        run: cp .env.production.example .env.production
+
       # Validate the compose file is syntactically valid before attempting the build.
       - name: Validate docker-compose.production.yml
         run: docker compose -f docker-compose.production.yml config >/dev/null

--- a/Dockerfile.frontend.prod
+++ b/Dockerfile.frontend.prod
@@ -10,6 +10,31 @@
 # ── Stage 1: build ───────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 ARG SPA
+
+# Production VITE_* build args. Values are non-secret (public URLs).
+# Vite bakes import.meta.env.VITE_* at build time, so they must be declared
+# here as ARG+ENV before `pnpm run build`. Passed by docker-compose.production.yml.
+# Same-origin model: each SPA's nginx reverse-proxies /api/* to Oathkeeper,
+# so API base paths use /api (relative) rather than absolute host URLs.
+#
+# -- Shared --
+ARG VITE_OATHKEEPER_URL
+ENV VITE_OATHKEEPER_URL=${VITE_OATHKEEPER_URL}
+
+# -- frontend-auth --
+ARG VITE_ALLOWED_REDIRECT_ORIGINS
+ENV VITE_ALLOWED_REDIRECT_ORIGINS=${VITE_ALLOWED_REDIRECT_ORIGINS}
+ARG VITE_DEFAULT_RETURN_URL
+ENV VITE_DEFAULT_RETURN_URL=${VITE_DEFAULT_RETURN_URL}
+
+# -- frontend-admin --
+ARG VITE_AUTH_UI_URL
+ENV VITE_AUTH_UI_URL=${VITE_AUTH_UI_URL}
+ARG VITE_KRATOS_BROWSER_URL
+ENV VITE_KRATOS_BROWSER_URL=${VITE_KRATOS_BROWSER_URL}
+ARG VITE_ADMIN_URL
+ENV VITE_ADMIN_URL=${VITE_ADMIN_URL}
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/Dockerfile.frontend.prod
+++ b/Dockerfile.frontend.prod
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+# Production multi-stage image for Nova ID SPAs (frontend-auth, frontend-admin).
+#
+# Build with:
+#   docker build -f Dockerfile.frontend.prod --build-arg SPA=frontend-auth -t nova-fe-auth:latest .
+#   docker build -f Dockerfile.frontend.prod --build-arg SPA=frontend-admin -t nova-fe-admin:latest .
+#
+# Build context must be the repo root (pnpm workspace root).
+
+# ── Stage 1: build ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+ARG SPA
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+# Mirror exact pnpm version pinned in root package.json ("pnpm@11.0.0")
+RUN corepack enable && corepack prepare pnpm@11.0.0 --activate
+
+WORKDIR /workspace
+
+# Copy workspace manifests first for layer-cached dependency install.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+
+# Copy each package's manifest so pnpm can resolve the workspace graph without
+# the full source tree.
+COPY packages/api-client/package.json ./packages/api-client/
+COPY frontend-auth/package.json  ./frontend-auth/
+COPY frontend-admin/package.json ./frontend-admin/
+COPY frontend-app/package.json   ./frontend-app/
+
+RUN pnpm install --frozen-lockfile
+
+# Now copy the full source (invalidates cache only when source changes).
+COPY . .
+
+# Generate the api-client from the OpenAPI spec before compiling the SPAs.
+# The generated files are gitignored; they must be produced at build time.
+RUN pnpm --filter @nova-id/api-client run generate
+
+# Build the target SPA. vue-tsc type-checks then vite produces /dist.
+RUN pnpm --filter "./${SPA}" run build
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM nginx:alpine AS runtime
+ARG SPA
+
+COPY config/nginx/spa.conf.template /etc/nginx/conf.d/default.conf
+COPY --from=builder /workspace/${SPA}/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+  CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1

--- a/Dockerfile.frontend.prod
+++ b/Dockerfile.frontend.prod
@@ -74,5 +74,7 @@ COPY --from=builder /workspace/${SPA}/dist /usr/share/nginx/html
 
 EXPOSE 80
 
+# Use 127.0.0.1 (not localhost): busybox wget resolves localhost to ::1 first,
+# but nginx listens on IPv4 :80 only, so localhost would fail the healthcheck.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
-  CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1
+  CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ dev: ## Start development (base stack, ports 5173/5174/5175, etc.)
 dev-local: ## Start development with local domains (auth.ory.localhost, etc.) and local-proxy on port 80
 	docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
 
-prod: ## Start production (base + production override, Traefik; use start-production.sh for full check)
-	docker compose -f docker-compose.yml -f docker-compose.production.yml up -d
+prod: ## Start production (standalone compose, Traefik; use start-production.sh for full preflight check)
+	docker compose -f docker-compose.production.yml up -d
 
 stop: ## Stop development stack (docker compose down)
 	docker compose down
 
 stop-prod: ## Stop production stack
-	docker compose -f docker-compose.yml -f docker-compose.production.yml down
+	docker compose -f docker-compose.production.yml down
 
 clean: ## Stop and remove all containers, volumes, and networks (dev stack)
 	docker compose down -v

--- a/README-DOMAINS.md
+++ b/README-DOMAINS.md
@@ -8,7 +8,7 @@ Este documento describe la configuración de dominios locales y de producción p
 |----------|-------|------------|
 | Kratos Self-Service UI | `http://auth.local` | `https://auth.cativo.dev` |
 | Admin Dashboard | `http://admin.local` | `https://admin.cativo.dev` |
-| API Gateway (Oathkeeper) | `http://api.local` | `https://api.cativo.dev` |
+| API Gateway (Oathkeeper) | `http://api.local` | `https://id.cativo.dev` |
 
 ## Setup Local
 
@@ -72,7 +72,7 @@ Asegúrate de que estos dominios apunten a tu servidor:
 
 - `auth.cativo.dev` → IP del servidor
 - `admin.cativo.dev` → IP del servidor
-- `api.cativo.dev` → IP del servidor
+- `id.cativo.dev` → IP del servidor
 
 ### 2. Configurar Variables de Entorno
 
@@ -123,7 +123,7 @@ Este script:
 Abre en tu navegador:
 - https://auth.cativo.dev - Kratos Self-Service UI
 - https://admin.cativo.dev - Admin Dashboard
-- https://api.cativo.dev - API Gateway
+- https://id.cativo.dev - API Gateway
 
 ### Ver Logs
 

--- a/config/hydra/hydra.production.yml
+++ b/config/hydra/hydra.production.yml
@@ -14,7 +14,7 @@ serve:
       allowed_origins:
         - https://auth.cativo.dev
         - https://admin.cativo.dev
-        - https://api.cativo.dev
+        - https://id.cativo.dev
       allowed_methods:
         - POST
         - GET
@@ -38,7 +38,7 @@ serve:
       allowed_origins:
         - https://auth.cativo.dev
         - https://admin.cativo.dev
-        - https://api.cativo.dev
+        - https://id.cativo.dev
       allowed_methods:
         - POST
         - GET
@@ -62,12 +62,12 @@ serve:
 
 urls:
   self:
-    issuer: https://api.cativo.dev
+    issuer: https://id.cativo.dev/
   consent: https://auth.cativo.dev/auth/consent
   login: https://auth.cativo.dev/auth/login
   logout: https://auth.cativo.dev/auth/logout
-  error: https://api.cativo.dev/error
-  post_logout_redirect: https://api.cativo.dev
+  error: https://id.cativo.dev/error
+  post_logout_redirect: https://id.cativo.dev
 
 strategies:
   access_token: jwt

--- a/config/nginx/spa.conf.template
+++ b/config/nginx/spa.conf.template
@@ -1,0 +1,65 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Static assets — long-lived cache with immutable marker.
+    # Matched before the SPA fallback so hashed filenames are cached aggressively.
+    location ~* \.(js|css|woff2?|svg|png|jpg|jpeg|gif|ico)$ {
+        expires 7d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Same-origin gateway proxy — keeps cookies first-party, no CORS.
+    #
+    # Only /api/ is proxied. In production, both SPAs set VITE_OATHKEEPER_URL=/api
+    # and VITE_KRATOS_PUBLIC_URL=/api, so all cross-service calls go through
+    # /api/* regardless of the underlying service (Kratos, Hydra, NestJS, Keto).
+    # Oathkeeper's production rules then route /api/(self-service|sessions|schemas)
+    # to Kratos, /api/hydra-* to Hydra, /api/v1/* to the NestJS API, etc.
+    #
+    # /admin/*, /login, /consent and the SPA-owned /auth/* view routes fall
+    # through to index.html — proxying them to Oathkeeper would loop back here.
+    # The one /auth/ exception (self-service/sessions) is handled by the rule
+    # below, which is matched before this prefix because regex locations win.
+    location /api/ {
+        proxy_pass http://oathkeeper:4455;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_pass_request_headers         on;
+    }
+
+    # Kratos self-service links under /auth/ — auth SPA only.
+    #
+    # Production Kratos public base_url is https://auth.cativo.dev/auth/ (see
+    # config/kratos/kratos.production.yml), so verification/recovery email links
+    # and self-service flow/action URLs are emitted under /auth/self-service/...
+    # and /auth/sessions/.... Those must reach Kratos via the gateway, not the
+    # SPA index.html fallback. Rewrite /auth/<rest> -> /api/<rest> so Oathkeeper's
+    # kratos-public rule routes them. The admin SPA never receives these requests
+    # (Kratos links target the auth host), so this rule is inert there — keeping
+    # one shared template is simpler than splitting per-SPA.
+    location ~ ^/auth/(self-service|sessions)/ {
+        rewrite ^/auth/(.*)$ /api/$1 break;
+        proxy_pass http://oathkeeper:4455;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_pass_request_headers         on;
+    }
+
+    # SPA history-mode fallback — must be last.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/config/oathkeeper/oathkeeper.production.yml
+++ b/config/oathkeeper/oathkeeper.production.yml
@@ -10,7 +10,7 @@ serve:
       allowed_origins:
         - https://auth.cativo.dev
         - https://admin.cativo.dev
-        - https://api.cativo.dev
+        - https://id.cativo.dev
       allowed_methods:
         - POST
         - GET
@@ -118,7 +118,7 @@ mutators:
   id_token:
     enabled: true
     config:
-      issuer_url: https://api.cativo.dev/
+      issuer_url: https://id.cativo.dev/
       jwks_url: file:///etc/config/oathkeeper/id_token.jwks.json
       claims: |
         {

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -6,179 +6,71 @@
       "url": "http://oathkeeper:4456"
     },
     "match": {
-      "url": "<(http|https)://id\\.cativo\\.dev/health/.*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/health/.*>",
       "methods": ["GET"]
     },
-    "authenticators": [
-      {
-        "handler": "noop"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
   },
   {
     "id": "kratos-public",
     "upstream": {
       "preserve_host": false,
+      "strip_path": "/api",
       "url": "http://kratos:4433"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/(self-service|sessions|health|schemas).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(self-service|sessions|schemas).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
-    "authenticators": [
-      {
-        "handler": "noop"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
   },
   {
-    "id": "hydra-public",
+    "id": "oauth2-public",
+    "upstream": {
+      "preserve_host": false,
+      "url": "http://hydra:4444"
+    },
+    "match": {
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/oauth2/.*>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    },
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
+  },
+  {
+    "id": "hydra-public-proxy",
     "upstream": {
       "preserve_host": false,
       "strip_path": "/hydra-public",
       "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/hydra-public/(oauth2|health|version|\\.well-known).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/hydra-public/(oauth2|health|version|\\.well-known).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     },
-    "authenticators": [
-      {
-        "handler": "noop"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
   },
   {
-    "id": "frontend-auth",
+    "id": "hydra-public",
     "upstream": {
       "preserve_host": false,
-      "url": "http://frontend-auth:5173"
+      "strip_path": "/api/hydra-public",
+      "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev)/auth/.*>",
-      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/hydra-public/(oauth2|health|version|\\.well-known).*>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     },
-    "authenticators": [
-      {
-        "handler": "noop"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
-  },
-  {
-    "id": "frontend-admin",
-    "upstream": {
-      "preserve_host": false,
-      "url": "http://frontend-admin:5174"
-    },
-    "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|admin\\.cativo\\.dev)/admin/.*>",
-      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
-    },
-    "authenticators": [
-      {
-        "handler": "cookie_session"
-      }
-    ],
-    "authorizer": {
-      "handler": "remote_json",
-      "config": {
-        "remote": "http://keto:4466/relation-tuples/check",
-        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"administer\",\"subject_id\":\"user:{{ print .Subject }}\"}",
-        "forward_response_headers_to_upstream": ["Content-Type"]
-      }
-    },
-    "mutators": [
-      {
-        "handler": "header",
-        "config": {
-          "headers": {
-            "X-User-ID": "{{ print .Subject }}",
-            "X-User-Email": "{{ print .Extra.identity.traits.email }}",
-            "X-User-Role": "{{ if .Extra.identity.metadata_public }}{{ print .Extra.identity.metadata_public.role }}{{ end }}"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "id": "hydra-login",
-    "upstream": {
-      "preserve_host": false,
-      "url": "http://frontend-auth:5173/auth/login"
-    },
-    "match": {
-      "url": "<(http|https)://id\\.cativo\\.dev/login>",
-      "methods": ["GET", "POST"]
-    },
-    "authenticators": [
-      {
-        "handler": "noop"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
-  },
-  {
-    "id": "hydra-consent",
-    "upstream": {
-      "preserve_host": false,
-      "url": "http://frontend-auth:5173/consent"
-    },
-    "match": {
-      "url": "<(http|https)://id\\.cativo\\.dev/consent>",
-      "methods": ["GET", "POST"]
-    },
-    "authenticators": [
-      {
-        "handler": "cookie_session"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
   },
   {
     "id": "public-api",
@@ -188,22 +80,12 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(health|public)>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(health|public)>",
       "methods": ["GET", "OPTIONS"]
     },
-    "authenticators": [
-      {
-        "handler": "noop"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      {
-        "handler": "noop"
-      }
-    ]
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
   },
   {
     "id": "api-hydra-accept",
@@ -213,7 +95,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(hydra-accept-login|hydra-accept-consent)>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(hydra-accept-login|hydra-accept-consent)>",
       "methods": ["POST", "OPTIONS"]
     },
     "authenticators": [
@@ -227,81 +109,8 @@
         }
       }
     ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      { "handler": "id_token" }
-    ]
-  },
-  {
-    "id": "me-permissions",
-    "upstream": {
-      "preserve_host": true,
-      "strip_path": "/api",
-      "url": "http://api:8080"
-    },
-    "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/me/permissions(/.*)?>",
-      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
-    },
-    "authenticators": [
-      {
-        "handler": "cookie_session",
-        "config": {
-          "check_session_url": "http://kratos:4433/sessions/whoami",
-          "preserve_path": true,
-          "extra_from": "@this",
-          "subject_from": "identity.id"
-        }
-      },
-      {
-        "handler": "oauth2_introspection"
-      }
-    ],
-    "authorizer": {
-      "handler": "allow"
-    },
-    "mutators": [
-      { "handler": "id_token" }
-    ]
-  },
-  {
-    "id": "protected-admin",
-    "upstream": {
-      "preserve_host": true,
-      "strip_path": "/api",
-      "url": "http://api:8080"
-    },
-    "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/admin(?!-)(/.*)?>",
-      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
-    },
-    "authenticators": [
-      {
-        "handler": "cookie_session",
-        "config": {
-          "check_session_url": "http://kratos:4433/sessions/whoami",
-          "preserve_path": true,
-          "extra_from": "@this",
-          "subject_from": "identity.id"
-        }
-      },
-      {
-        "handler": "oauth2_introspection"
-      }
-    ],
-    "authorizer": {
-      "handler": "remote_json",
-      "config": {
-        "remote": "http://keto:4466/relation-tuples/check",
-        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"administer\",\"subject_id\":\"user:{{ print .Subject }}\"}",
-        "forward_response_headers_to_upstream": ["Content-Type"]
-      }
-    },
-    "mutators": [
-      { "handler": "id_token" }
-    ]
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "id_token" }]
   },
   {
     "id": "api-roles-bootstrap",
@@ -311,7 +120,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/roles/bootstrap(/.*)?$>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/roles/bootstrap(/.*)?$>",
       "methods": ["POST", "OPTIONS"]
     },
     "authenticators": [
@@ -324,9 +133,7 @@
           "subject_from": "identity.id"
         }
       },
-      {
-        "handler": "oauth2_introspection"
-      }
+      { "handler": "oauth2_introspection" }
     ],
     "authorizer": {
       "handler": "remote_json",
@@ -336,24 +143,79 @@
         "forward_response_headers_to_upstream": ["Content-Type"]
       }
     },
-    "mutators": [ { "handler": "id_token" } ]
+    "mutators": [{ "handler": "id_token" }]
+  },
+  {
+    "id": "me-permissions",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api",
+      "url": "http://api:8080"
+    },
+    "match": {
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/me/permissions(/.*)?>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    },
+    "authenticators": [
+      {
+        "handler": "cookie_session",
+        "config": {
+          "check_session_url": "http://kratos:4433/sessions/whoami",
+          "preserve_path": true,
+          "extra_from": "@this",
+          "subject_from": "identity.id"
+        }
+      },
+      { "handler": "oauth2_introspection" }
+    ],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "id_token" }]
+  },
+  {
+    "id": "protected-admin",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api",
+      "url": "http://api:8080"
+    },
+    "match": {
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/admin(?!-)(/.*)?>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    },
+    "authenticators": [
+      {
+        "handler": "cookie_session",
+        "config": {
+          "check_session_url": "http://kratos:4433/sessions/whoami",
+          "preserve_path": true,
+          "extra_from": "@this",
+          "subject_from": "identity.id"
+        }
+      },
+      { "handler": "oauth2_introspection" }
+    ],
+    "authorizer": {
+      "handler": "remote_json",
+      "config": {
+        "remote": "http://keto:4466/relation-tuples/check",
+        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"administer\",\"subject_id\":\"user:{{ print .Subject }}\"}",
+        "forward_response_headers_to_upstream": ["Content-Type"]
+      }
+    },
+    "mutators": [{ "handler": "id_token" }]
   },
   {
     "id": "keto-read",
     "upstream": {
       "preserve_host": false,
-      "strip_path": "/keto/read",
+      "strip_path": "/api/keto/read",
       "url": "http://keto:4466"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/keto/read/.*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/keto/read/.*>",
       "methods": ["GET", "POST"]
     },
-    "authenticators": [
-      {
-        "handler": "cookie_session"
-      }
-    ],
+    "authenticators": [{ "handler": "cookie_session" }],
     "authorizer": {
       "handler": "remote_json",
       "config": {

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -6,7 +6,7 @@
       "url": "http://oathkeeper:4456"
     },
     "match": {
-      "url": "<(http|https)://api\\.cativo\\.dev/health/.*>",
+      "url": "<(http|https)://id\\.cativo\\.dev/health/.*>",
       "methods": ["GET"]
     },
     "authenticators": [
@@ -30,7 +30,7 @@
       "url": "http://kratos:4433"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/(self-service|sessions|health|schemas).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/(self-service|sessions|health|schemas).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [
@@ -55,7 +55,7 @@
       "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/hydra-public/(oauth2|health|version|\\.well-known).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/hydra-public/(oauth2|health|version|\\.well-known).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     },
     "authenticators": [
@@ -79,7 +79,7 @@
       "url": "http://frontend-auth:5173"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|auth\\.cativo\\.dev)/auth/.*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev)/auth/.*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
     },
     "authenticators": [
@@ -103,7 +103,7 @@
       "url": "http://frontend-admin:5174"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|admin\\.cativo\\.dev)/admin/.*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|admin\\.cativo\\.dev)/admin/.*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
     },
     "authenticators": [
@@ -139,7 +139,7 @@
       "url": "http://frontend-auth:5173/auth/login"
     },
     "match": {
-      "url": "<(http|https)://api\\.cativo\\.dev/login>",
+      "url": "<(http|https)://id\\.cativo\\.dev/login>",
       "methods": ["GET", "POST"]
     },
     "authenticators": [
@@ -163,7 +163,7 @@
       "url": "http://frontend-auth:5173/consent"
     },
     "match": {
-      "url": "<(http|https)://api\\.cativo\\.dev/consent>",
+      "url": "<(http|https)://id\\.cativo\\.dev/consent>",
       "methods": ["GET", "POST"]
     },
     "authenticators": [
@@ -188,7 +188,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(health|public)>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(health|public)>",
       "methods": ["GET", "OPTIONS"]
     },
     "authenticators": [
@@ -213,7 +213,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(hydra-accept-login|hydra-accept-consent)>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/(hydra-accept-login|hydra-accept-consent)>",
       "methods": ["POST", "OPTIONS"]
     },
     "authenticators": [
@@ -242,7 +242,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/me/permissions(/.*)?>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/me/permissions(/.*)?>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [
@@ -274,7 +274,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/admin(?!-)(/.*)?>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/v1/admin(?!-)(/.*)?>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [
@@ -311,7 +311,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/roles/bootstrap(/.*)?$>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/roles/bootstrap(/.*)?$>",
       "methods": ["POST", "OPTIONS"]
     },
     "authenticators": [
@@ -346,7 +346,7 @@
       "url": "http://keto:4466"
     },
     "match": {
-      "url": "<(http|https)://(api\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/keto/read/.*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/keto/read/.*>",
       "methods": ["GET", "POST"]
     },
     "authenticators": [

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,66 +1,402 @@
-# Docker Compose override for production
-# Usage: docker-compose -f docker-compose.yml -f docker-compose.production.yml up
-# IMPORTANT: Connects to existing Traefik network (space-server_web)
-
-version: '3.8'
+# Self-contained production Compose file for Nova ID.
+#
+# Usage: docker compose -f docker-compose.production.yml up -d
+#
+# This file is intentionally NOT an override of docker-compose.yml.
+# Docker Compose list merging (volumes, ports, depends_on) makes a thin override
+# unable to shed the dev bind-mount `./api:/app`, which would shadow the built
+# /app/dist in the prod API image and break `node dist/main`. Standalone avoids
+# that class of bug entirely.
+#
+# Dev stack (make dev / make dev-local) continues to use docker-compose.yml
+# and docker-compose.local.yml — this file is production-only.
+#
+# Networks use distinct names from the dev stack so both can coexist on the same
+# host (useful for canary deploys or side-by-side testing):
+#   dev:  nova-id-ory-internal  /  nova-id-apps
+#   prod: nova-id-ory-internal-prod  /  nova-id-apps-prod
+#
+# api_logs is kept as a named volume for persistent log retention across container
+# restarts. The source bind-mount (./api:/app) and the anonymous /app/node_modules
+# volume from the dev service are NOT present here.
 
 services:
+
+  # ── Database ─────────────────────────────────────────────────────────────────
+
   postgres:
-    ports: []  # No exposed ports in production
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./config/init-sql/create-dbs.sql:/docker-entrypoint-initdb.d/create-dbs.sql:ro
+    # No published ports in production — DB is reachable only on ory-internal.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - ory-internal
+    restart: unless-stopped
+
+  postgres-init:
+    image: postgres:15-alpine
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      ORY_PASSWORD: ${ORY_PASSWORD}
+      KRATOS_DB_PASSWORD: ${KRATOS_DB_PASSWORD}
+      HYDRA_DB_PASSWORD: ${HYDRA_DB_PASSWORD}
+      KETO_DB_PASSWORD: ${KETO_DB_PASSWORD}
+    command: >
+      sh -c "
+        until pg_isready -h postgres -U postgres; do sleep 1; done &&
+        bash /docker-entrypoint-initdb.d/create-users.sh
+      "
+    volumes:
+      - ./config/init-sql/create-users.sh:/docker-entrypoint-initdb.d/create-users.sh:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - ory-internal
+    restart: "no"
+
+  # ── Kratos ───────────────────────────────────────────────────────────────────
+
+  kratos-migrate:
+    image: oryd/kratos:v25.4.0
+    environment:
+      # Ory path-mapped env vars: dots→underscores, uppercase. KRATOS_ prefix is
+      # NOT recognized — the correct names are SECRETS_*, DSN, etc.
+      - DSN=postgres://kratos_user:${KRATOS_DB_PASSWORD}@postgres:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+      - SECRETS_COOKIE=${KRATOS_SECRETS_COOKIE}
+      - SECRETS_CIPHER=${KRATOS_SECRETS_CIPHER}
+      - SECRETS_DEFAULT=${KRATOS_SECRETS_DEFAULT}
+    # Config hardcoded to production — no ${ENVIRONMENT} variable substitution.
+    command: -c /etc/config/kratos/kratos.production.yml migrate sql -e --yes
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    env_file:
+      - .env.production
+    depends_on:
+      postgres-init:
+        condition: service_completed_successfully
+    networks:
+      - ory-internal
+    restart: "no"
 
   kratos:
-    ports: []  # No exposed ports - only accessible through Oathkeeper
+    image: oryd/kratos:v25.4.0
+    environment:
+      # Ory path-mapped env vars: dots→underscores, uppercase. KRATOS_ prefix is
+      # NOT recognized — the correct names are SECRETS_*, DSN, COURIER_SMTP_*, etc.
+      - DSN=postgres://kratos_user:${KRATOS_DB_PASSWORD}@postgres:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+      - SECRETS_COOKIE=${KRATOS_SECRETS_COOKIE}
+      - SECRETS_CIPHER=${KRATOS_SECRETS_CIPHER}
+      - SECRETS_DEFAULT=${KRATOS_SECRETS_DEFAULT}
+      - COURIER_SMTP_CONNECTION_URI=${SMTP_CONNECTION_URI}
+      - COURIER_SMTP_FROM_ADDRESS=${SMTP_FROM_ADDRESS}
+    # --watch-courier runs the mail courier worker for recovery/verification emails.
+    # --dev flag is intentionally absent in production.
+    command: serve -c /etc/config/kratos/kratos.production.yml --watch-courier
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:4433/health/ready",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - .env.production
+    networks:
+      - ory-internal
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  # ── Hydra ────────────────────────────────────────────────────────────────────
+
+  hydra-migrate:
+    image: oryd/hydra:v25.4.0
+    environment:
+      - DSN=postgres://hydra_user:${HYDRA_DB_PASSWORD}@postgres:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+      - HYDRA_DB_PASSWORD=${HYDRA_DB_PASSWORD}
+      # Ory path-mapped env var: secrets.system ← SECRETS_SYSTEM. The HYDRA_ prefix is
+      # NOT recognized and Ory does NOT expand ${VAR} in YAML.
+      - SECRETS_SYSTEM=${HYDRA_SYSTEM_SECRET}
+    # Config hardcoded to production — no --dev flag.
+    command: migrate sql -e --yes -c /etc/config/hydra/hydra.production.yml
+    volumes:
+      - ./config/hydra:/etc/config/hydra:ro
+    env_file:
+      - .env.production
+    depends_on:
+      postgres-init:
+        condition: service_completed_successfully
+    networks:
+      - ory-internal
+    restart: "no"
 
   hydra:
-    ports: []  # No exposed ports - only accessible through Oathkeeper
+    image: oryd/hydra:v25.4.0
+    environment:
+      - DSN=postgres://hydra_user:${HYDRA_DB_PASSWORD}@postgres:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+      - HYDRA_DB_PASSWORD=${HYDRA_DB_PASSWORD}
+      # Ory path-mapped env var: secrets.system ← SECRETS_SYSTEM.
+      - SECRETS_SYSTEM=${HYDRA_SYSTEM_SECRET}
+    # No --dev flag in production.
+    command: serve all -c /etc/config/hydra/hydra.production.yml
+    volumes:
+      - ./config/hydra:/etc/config/hydra:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:4444/health/ready",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - .env.production
+    networks:
+      - ory-internal
+    depends_on:
+      hydra-migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  # ── Keto ─────────────────────────────────────────────────────────────────────
+
+  keto-migrate:
+    image: oryd/keto:v25.4.0
+    environment:
+      - DSN=postgres://keto_user:${KETO_DB_PASSWORD}@postgres:5432/keto?sslmode=disable&max_conns=20&max_idle_conns=4
+      - KETO_DB_PASSWORD=${KETO_DB_PASSWORD}
+    # Config hardcoded to production.
+    command: migrate up -c /etc/config/keto/keto.production.yml --yes
+    volumes:
+      - ./config/keto:/etc/config/keto:ro
+    env_file:
+      - .env.production
+    depends_on:
+      postgres-init:
+        condition: service_completed_successfully
+    networks:
+      - ory-internal
+    restart: "no"
 
   keto:
-    ports: []  # No exposed ports - only accessible through Oathkeeper
+    image: oryd/keto:v25.4.0
+    environment:
+      - DSN=postgres://keto_user:${KETO_DB_PASSWORD}@postgres:5432/keto?sslmode=disable&max_conns=20&max_idle_conns=4
+      - KETO_DB_PASSWORD=${KETO_DB_PASSWORD}
+    # Config hardcoded to production.
+    command: serve -c /etc/config/keto/keto.production.yml
+    volumes:
+      - ./config/keto:/etc/config/keto:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:4466/health/ready",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - .env.production
+    networks:
+      - ory-internal
+    depends_on:
+      keto-migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  # ── Oathkeeper (gateway / PEP) ────────────────────────────────────────────────
+  # Oathkeeper is the single public entry point. Traefik routes id.cativo.dev to
+  # port 4455. It sits on ory-internal (to reach Kratos/Keto/Hydra) and apps (to
+  # proxy to the API) and web (for Traefik to discover it).
+
+  oathkeeper:
+    image: oryd/oathkeeper:v25.4.0
+    # Config hardcoded to production.
+    command: serve -c /etc/config/oathkeeper/oathkeeper.production.yml
+    volumes:
+      - ./config/oathkeeper:/etc/config/oathkeeper:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:4456/health/ready",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - .env.production
+    networks:
+      - ory-internal
+      - apps
+      - web
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=space-server_web"
+      - "traefik.http.routers.oathkeeper.rule=Host(`id.cativo.dev`)"
+      - "traefik.http.routers.oathkeeper.entrypoints=websecure"
+      - "traefik.http.routers.oathkeeper.tls.certresolver=letsencryptresolver"
+      - "traefik.http.services.oathkeeper.loadbalancer.server.port=4455"
+    depends_on:
+      kratos:
+        condition: service_healthy
+      keto:
+        condition: service_healthy
+      hydra:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── NestJS API ────────────────────────────────────────────────────────────────
+  # Built from the production multi-stage Dockerfile (api/Dockerfile).
+  # ZERO TRUST: no published ports — reachable only via Oathkeeper on the apps
+  # and ory-internal networks.
 
   api:
-    ports: []  # No exposed ports - only reachable via Oathkeeper
-
-  frontend-auth:
-    ports: []  # No exposed ports - Traefik handles routing
+    build:
+      context: ./api
+      dockerfile: Dockerfile
+    command: ["node", "dist/main"]
+    # No source bind-mount. No anonymous /app/node_modules.
+    # api_logs provides persistent log retention across restarts.
+    volumes:
+      - api_logs:/app/logs
+    env_file:
+      - .env.production
+    environment:
+      - NODE_ENV=production
+      - PORT=8080
+      - OATHKEEPER_URL=http://oathkeeper:4455
+      - HYDRA_ADMIN_URL=http://hydra:4445
+      - KRATOS_ADMIN_URL=http://kratos:4434
+      - KETO_READ_URL=http://keto:4466
+      - AUDIT_DB_HOST=postgres
+      - AUDIT_DB_PORT=5432
+      - AUDIT_DB_NAME=nova_audit
+      - AUDIT_DB_USER=postgres
+      - AUDIT_DB_PASSWORD=${POSTGRES_PASSWORD}
     networks:
       - apps
-      - web  # Traefik network
+      - ory-internal
+    depends_on:
+      oathkeeper:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── Frontend SPAs (nginx) ─────────────────────────────────────────────────────
+  # Each SPA is a pre-built nginx:alpine image produced by Dockerfile.frontend.prod.
+  # They serve static assets on port 80; Traefik terminates TLS externally.
+  #
+  # Network reasoning: frontends need `web` so Traefik can discover them. They
+  # also need `apps` so their nginx proxy_pass rules can reach oathkeeper:4455
+  # (oathkeeper is on both ory-internal and apps; frontends are not on ory-internal
+  # — they must never reach Ory services directly). The `ory-internal` network is
+  # intentionally omitted from frontends to preserve the zero-trust boundary.
+
+  frontend-auth:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend.prod
+      args:
+        SPA: frontend-auth
+    # nginx starts by default — no command override needed.
+    # No bind-mounts in production — static files are baked into the image.
+    networks:
+      - apps
+      - web
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=space-server_web"
       - "traefik.http.routers.frontend-auth.rule=Host(`auth.cativo.dev`)"
       - "traefik.http.routers.frontend-auth.entrypoints=websecure"
-      - "traefik.http.routers.frontend-auth.tls.certresolver=letsencrypt"
-      - "traefik.http.services.frontend-auth.loadbalancer.server.port=5173"
+      - "traefik.http.routers.frontend-auth.tls.certresolver=letsencryptresolver"
+      - "traefik.http.services.frontend-auth.loadbalancer.server.port=80"
+    depends_on:
+      oathkeeper:
+        condition: service_healthy
+    restart: unless-stopped
 
   frontend-admin:
-    ports: []  # No exposed ports - Traefik handles routing
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend.prod
+      args:
+        SPA: frontend-admin
     networks:
       - apps
-      - web  # Traefik network
+      - web
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=space-server_web"
       - "traefik.http.routers.frontend-admin.rule=Host(`admin.cativo.dev`)"
       - "traefik.http.routers.frontend-admin.entrypoints=websecure"
-      - "traefik.http.routers.frontend-admin.tls.certresolver=letsencrypt"
-      - "traefik.http.services.frontend-admin.loadbalancer.server.port=5174"
+      - "traefik.http.routers.frontend-admin.tls.certresolver=letsencryptresolver"
+      - "traefik.http.services.frontend-admin.loadbalancer.server.port=80"
+    depends_on:
+      oathkeeper:
+        condition: service_healthy
+    restart: unless-stopped
 
-  oathkeeper:
-    ports: []  # No exposed ports - Traefik handles routing
-    networks:
-      - ory-internal
-      - apps
-      - web  # Traefik network
-    labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=space-server_web"
-      - "traefik.http.routers.oathkeeper.rule=Host(`api.cativo.dev`)"
-      - "traefik.http.routers.oathkeeper.entrypoints=websecure"
-      - "traefik.http.routers.oathkeeper.tls.certresolver=letsencrypt"
-      - "traefik.http.services.oathkeeper.loadbalancer.server.port=4455"
+# ── Volumes ───────────────────────────────────────────────────────────────────
+
+volumes:
+  postgres_data:
+    driver: local
+  api_logs:
+    driver: local
+
+# ── Networks ──────────────────────────────────────────────────────────────────
+#
+# Distinct names from the dev stack (nova-id-ory-internal / nova-id-apps) so
+# both stacks can coexist on the same host without network collisions:
+#   dev:  nova-id-ory-internal  /  nova-id-apps
+#   prod: nova-id-ory-internal-prod  /  nova-id-apps-prod
 
 networks:
+  ory-internal:
+    driver: bridge
+    name: nova-id-ory-internal-prod
+
+  apps:
+    driver: bridge
+    name: nova-id-apps-prod
+
   web:
     external: true
     name: space-server_web

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -335,6 +335,15 @@ services:
       dockerfile: Dockerfile.frontend.prod
       args:
         SPA: frontend-auth
+        # API base — same-origin: nginx proxy_pass /api/* → oathkeeper:4455.
+        # Overrides the useAuth.ts fallback of 'http://localhost:4455'.
+        VITE_OATHKEEPER_URL: /api
+        # Open-redirect allowlist — comma-separated, parsed by safeRedirect.ts.
+        VITE_ALLOWED_REDIRECT_ORIGINS: "https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev"
+        # Post-login fallback when no return_to / login_challenge is present.
+        # Defaults to 'http://app.ory.localhost' in code — must be prod URL.
+        # frontend-app is not deployed; auth.cativo.dev is the neutral fallback.
+        VITE_DEFAULT_RETURN_URL: "https://auth.cativo.dev"
     # nginx starts by default — no command override needed.
     # No bind-mounts in production — static files are baked into the image.
     networks:
@@ -358,6 +367,20 @@ services:
       dockerfile: Dockerfile.frontend.prod
       args:
         SPA: frontend-admin
+        # API base — same-origin: nginx proxy_pass /api/* → oathkeeper:4455.
+        # Overrides the useAuth.ts fallback of 'http://localhost:4455'.
+        VITE_OATHKEEPER_URL: /api
+        # Auth SPA URL — used for login redirect (Home.vue) and logout URL
+        # normalisation (useAuth.ts getAuthBaseUrl fallback chain).
+        VITE_AUTH_UI_URL: "https://auth.cativo.dev"
+        # Kratos browser (public) base for the auth SPA routes.
+        # Used by getAuthBaseUrl() and recovery link normalisation.
+        VITE_KRATOS_BROWSER_URL: "https://auth.cativo.dev/auth"
+        # Admin SPA URL — used as returnTo for verification email flows.
+        VITE_ADMIN_URL: "https://admin.cativo.dev"
+        # VITE_AUDIT_API_URL intentionally omitted: the API has no public HTTP
+        # audit ingestion endpoint (AuditService is internal). Leaving it unset
+        # triggers the no-op branch in useAuditLog.ts (if (!auditUrl) return).
     networks:
       - apps
       - web

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,13 @@ packages:
   - 'frontend-auth'
   - 'frontend-admin'
   - 'frontend-app'
-# pnpm 10+ blocks dependency build scripts by default. esbuild (Vite's bundler)
-# needs its postinstall to fetch/build its native binary — allow only that one.
-onlyBuiltDependencies:
-  - esbuild
+# pnpm 11 blocks dependency build scripts by default. esbuild (Vite's bundler)
+# needs its postinstall to fetch/build its native binary; vue-demi runs a postinstall
+# to set up Vue 2/3 interop. allowBuilds is the pnpm 11 field (onlyBuiltDependencies
+# is a pnpm 10 alias that pnpm 11.0.0 does not recognise).
+allowBuilds:
+  esbuild: true
+  vue-demi: true
 
 # pnpm re-runs `install` before every `pnpm run` script; the native build-script
 # gate (esbuild/vue-demi) makes that precheck exit non-zero even when node_modules

--- a/start-production.sh
+++ b/start-production.sh
@@ -50,7 +50,7 @@ export ENVIRONMENT=production
 
 # Start services
 echo -e "${BLUE}🐳 Starting Docker Compose services...${NC}"
-docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d
+docker compose -f docker-compose.production.yml up -d
 
 echo ""
 echo -e "${GREEN}✅ Nova ID Stack started successfully!${NC}"
@@ -61,8 +61,8 @@ echo "  - Admin:       https://admin.cativo.dev"
 echo "  - API Gateway: https://api.cativo.dev"
 echo ""
 echo -e "${BLUE}🔍 View logs:${NC}"
-echo "  docker-compose -f docker-compose.yml -f docker-compose.production.yml logs -f"
+echo "  docker compose -f docker-compose.production.yml logs -f"
 echo ""
 echo -e "${BLUE}🛑 Stop services:${NC}"
-echo "  docker-compose -f docker-compose.yml -f docker-compose.production.yml down"
+echo "  docker compose -f docker-compose.production.yml down"
 echo ""

--- a/start-production.sh
+++ b/start-production.sh
@@ -35,7 +35,7 @@ echo ""
 
 # Check DNS configuration
 echo -e "${BLUE}📋 Checking DNS configuration...${NC}"
-DOMAINS=("auth.cativo.dev" "admin.cativo.dev" "api.cativo.dev")
+DOMAINS=("auth.cativo.dev" "admin.cativo.dev" "id.cativo.dev")
 echo "Make sure these domains point to this server:"
 for domain in "${DOMAINS[@]}"; do
     echo "  - ${domain}"
@@ -58,7 +58,7 @@ echo ""
 echo -e "${BLUE}📍 Available URLs:${NC}"
 echo "  - Auth UI:     https://auth.cativo.dev"
 echo "  - Admin:       https://admin.cativo.dev"
-echo "  - API Gateway: https://api.cativo.dev"
+echo "  - API Gateway: https://id.cativo.dev"
 echo ""
 echo -e "${BLUE}🔍 View logs:${NC}"
 echo "  docker compose -f docker-compose.production.yml logs -f"


### PR DESCRIPTION
## What this delivers (B1)

- **Production nginx SPA image** — `Dockerfile.frontend.prod` builds `frontend-auth` and `frontend-admin` as self-contained nginx images, with per-app VITE build args injected at build time (`VITE_KRATOS_URL`, `VITE_HYDRA_URL`, `VITE_API_URL`).
- **Self-contained `docker-compose.production.yml`** — no dev bind-mounts, no hot-reload services, fixed `certresolver: letsencryptresolver` (was broken `le`), all three Ory services wired to production config paths.
- **`api.cativo.dev` → `id.cativo.dev` rename** — issuer, nginx server_name, Hydra `URLS_SELF_ISSUER`, Kratos/Keto config, and all gateway references updated consistently. Issuer immutability rationale in `docs/decisions/` (ADR-0006).
- **`.env.production.example`** — documents every required runtime env var for the production stack; secrets are placeholders only.
- **CI `build-prod-images` gate** — new job in `.github/workflows/ci.yml` that validates `docker-compose.production.yml` parses cleanly and then runs `docker compose build` for all three custom images on every push/PR to develop+main. Build-only: no images are pushed, no deploy.

## Verification (local)

Production boot was verified locally:
- DB migrations ran clean
- Admin surface returned 401 (fail-closed) before authentication
- Gateway surface showed no unintended Ory admin exposure
- Hydra accepted `https://id.cativo.dev/` as issuer

## What comes next

- **B2** — manual first deploy to VPS (DNS + Traefik + secrets, no automation)
- **B3** — CD automation (deferred; out of scope for this PR)

## Notes

Trivy image scanning is not included in the CI gate. There is no registry push in this pipeline, so scanning build-time artifacts adds cost without actionable signal. Trivy will be wired in at B3 when images are pushed to a registry.