### PR TITLE
fix(deploy): auth SPA asset base + --env-file for prod compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ dev-local: ## Start development with local domains (auth.ory.localhost, etc.) an
 	docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
 
 prod: ## Start production (standalone compose, Traefik; use start-production.sh for full preflight check)
-	docker compose -f docker-compose.production.yml up -d
+	docker compose --env-file .env.production -f docker-compose.production.yml up -d
 
 stop: ## Stop development stack (docker compose down)
 	docker compose down
 
 stop-prod: ## Stop production stack
-	docker compose -f docker-compose.production.yml down
+	docker compose --env-file .env.production -f docker-compose.production.yml down
 
 clean: ## Stop and remove all containers, volumes, and networks (dev stack)
 	docker compose down -v

--- a/frontend-auth/vite.config.js
+++ b/frontend-auth/vite.config.js
@@ -3,7 +3,12 @@ import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],
-  base: '/auth/', // Base path for assets when served through Oathkeeper
+  // Asset base is '/' (served from the dedicated nginx host root in prod, and the
+  // Vite dev server / local-proxy at root in dev). The /auth/ URL prefix lives in
+  // the Vue Router base (main.ts) + Kratos base_url, NOT in the asset paths — keeping
+  // them coupled put built assets at /auth/assets/ which the prod nginx (serving at
+  // root) returned 404 for, blanking the SPA. Decoupled so assets resolve at /assets/.
+  base: '/',
   server: {
     host: '0.0.0.0',
     port: 5173,

--- a/start-production.sh
+++ b/start-production.sh
@@ -48,9 +48,12 @@ echo ""
 export $(cat .env.production | grep -v '^#' | xargs)
 export ENVIRONMENT=production
 
-# Start services
+# Start services. --env-file makes Compose interpolate ${VAR} in the YAML from
+# .env.production (env_file: only injects into containers, NOT into interpolation;
+# and Compose only auto-reads a file literally named `.env`). Without this, secrets
+# like ${POSTGRES_PASSWORD} resolve to empty and Postgres refuses to initialize.
 echo -e "${BLUE}🐳 Starting Docker Compose services...${NC}"
-docker compose -f docker-compose.production.yml up -d
+docker compose --env-file .env.production -f docker-compose.production.yml up -d --build
 
 echo ""
 echo -e "${GREEN}✅ Nova ID Stack started successfully!${NC}"
@@ -61,8 +64,8 @@ echo "  - Admin:       https://admin.cativo.dev"
 echo "  - API Gateway: https://id.cativo.dev"
 echo ""
 echo -e "${BLUE}🔍 View logs:${NC}"
-echo "  docker compose -f docker-compose.production.yml logs -f"
+echo "  docker compose --env-file .env.production -f docker-compose.production.yml logs -f"
 echo ""
 echo -e "${BLUE}🛑 Stop services:${NC}"
-echo "  docker compose -f docker-compose.production.yml down"
+echo "  docker compose --env-file .env.production -f docker-compose.production.yml down"
 echo ""


### PR DESCRIPTION
Two deploy-blocking issues found during the B2 manual bring-up on polaris2:

1. **auth SPA blank page** — `frontend-auth` Vite `base: '/auth/'` made built assets resolve at `/auth/assets/*`, but the production nginx serves the dist at root → JS/CSS 404 → blank SPA. Decoupled: asset base → `/` (matches `frontend-admin`); the `/auth/` URL prefix stays in the Vue Router base + Kratos `base_url`.
2. **prod compose interpolation** — `start-production.sh` + `Makefile` now pass `--env-file .env.production` so Compose interpolates `${VAR}` in the YAML. `env_file:` only injects into containers, and Compose auto-reads only a file named `.env`; without the flag `${POSTGRES_PASSWORD}` resolved empty and Postgres refused to init.

Found while deploying B1 (#49) live. Verified fix on polaris2 after merge.