### PR TITLE
feat: deploy demo app as OAuth2 RP + faithful architecture page

### DIFF
--- a/Dockerfile.frontend.prod
+++ b/Dockerfile.frontend.prod
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
-# Production multi-stage image for Nova ID SPAs (frontend-auth, frontend-admin).
+# Production multi-stage image for Nova ID SPAs (frontend-auth, frontend-admin, frontend-app).
 #
 # Build with:
 #   docker build -f Dockerfile.frontend.prod --build-arg SPA=frontend-auth -t nova-fe-auth:latest .
 #   docker build -f Dockerfile.frontend.prod --build-arg SPA=frontend-admin -t nova-fe-admin:latest .
+#   docker build -f Dockerfile.frontend.prod --build-arg SPA=frontend-app -t nova-fe-app:latest .
 #
 # Build context must be the repo root (pnpm workspace root).
 
@@ -34,6 +35,12 @@ ARG VITE_KRATOS_BROWSER_URL
 ENV VITE_KRATOS_BROWSER_URL=${VITE_KRATOS_BROWSER_URL}
 ARG VITE_ADMIN_URL
 ENV VITE_ADMIN_URL=${VITE_ADMIN_URL}
+
+# -- frontend-app (demo relying-party) --
+ARG VITE_APP_URL
+ENV VITE_APP_URL=${VITE_APP_URL}
+ARG VITE_NOVA_ID_CLIENT_ID
+ENV VITE_NOVA_ID_CLIENT_ID=${VITE_NOVA_ID_CLIENT_ID}
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/api/src/demo/demo-seed.service.ts
+++ b/api/src/demo/demo-seed.service.ts
@@ -26,6 +26,15 @@ export class DemoSeedService implements OnApplicationBootstrap {
   constructor(private readonly rolesService: RolesService) {}
 
   async onApplicationBootstrap(): Promise<void> {
+    // Never seed the local demo fixtures in production. The *.nova.test demo
+    // identities do not exist in a real deployment, so this would only emit
+    // noisy "identity not found" warnings on every boot. Production app-admin
+    // grants are provisioned explicitly per identity, not via this fixture seed.
+    if (process.env.NODE_ENV === 'production') {
+      this.logger.debug('NODE_ENV=production — skipping demo SQLite seed.');
+      return;
+    }
+
     const kratosAdminUrl = process.env.KRATOS_ADMIN_URL;
     if (!kratosAdminUrl) {
       this.logger.debug('KRATOS_ADMIN_URL not set — skipping demo SQLite seed.');

--- a/config/hydra/hydra.production.yml
+++ b/config/hydra/hydra.production.yml
@@ -15,6 +15,7 @@ serve:
         - https://auth.cativo.dev
         - https://admin.cativo.dev
         - https://id.cativo.dev
+        - https://app.cativo.dev
       allowed_methods:
         - POST
         - GET

--- a/config/nginx/spa.conf.template
+++ b/config/nginx/spa.conf.template
@@ -37,6 +37,25 @@ server {
         proxy_pass_request_headers         on;
     }
 
+    # Demo relying-party (frontend-app) API surface — same-origin like /api/.
+    #
+    # The demo app (app.cativo.dev) exercises the IdP as a real OAuth2 client and
+    # calls its sample resource server under /api-test/* (see useApiTest.ts). Those
+    # must reach Oathkeeper, which routes /api-test/(health|public) and the
+    # access-gated /api-test/* to the NestJS demo controller. This block is shared
+    # across all SPA images but is inert for auth/admin: Oathkeeper's rules are
+    # host-scoped, so /api-test/* on auth.cativo.dev / admin.cativo.dev has no
+    # matching rule and 404s. Only app.cativo.dev has the api-test rules.
+    location /api-test/ {
+        proxy_pass http://oathkeeper:4455;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_pass_request_headers         on;
+    }
+
     # Kratos self-service links under /auth/ — auth SPA only.
     #
     # Production Kratos public base_url is https://auth.cativo.dev/auth/ (see

--- a/config/oathkeeper/oathkeeper.production.yml
+++ b/config/oathkeeper/oathkeeper.production.yml
@@ -11,6 +11,7 @@ serve:
         - https://auth.cativo.dev
         - https://admin.cativo.dev
         - https://id.cativo.dev
+        - https://app.cativo.dev
       allowed_methods:
         - POST
         - GET

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -21,7 +21,7 @@
       "url": "http://kratos:4433"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(self-service|sessions|schemas).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(self-service|sessions|schemas).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -35,7 +35,7 @@
       "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/oauth2/.*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/oauth2/.*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -50,7 +50,7 @@
       "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/hydra-public/(oauth2|health|version|\\.well-known).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/hydra-public/(oauth2|health|version|\\.well-known).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -65,7 +65,7 @@
       "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/hydra-public/(oauth2|health|version|\\.well-known).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/hydra-public/(oauth2|health|version|\\.well-known).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -80,7 +80,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(health|public)>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api/(health|public)>",
       "methods": ["GET", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -235,5 +235,67 @@
         }
       }
     ]
+  },
+  {
+    "id": "well-known-oidc",
+    "upstream": {
+      "preserve_host": false,
+      "url": "http://hydra:4444"
+    },
+    "match": {
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/\\.well-known/(openid-configuration|jwks\\.json).*>",
+      "methods": ["GET", "OPTIONS"]
+    },
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
+  },
+  {
+    "id": "api-test-public",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api-test",
+      "url": "http://api:8080"
+    },
+    "match": {
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api-test/(health|public)>",
+      "methods": ["GET", "OPTIONS"]
+    },
+    "authenticators": [{ "handler": "noop" }],
+    "authorizer": { "handler": "allow" },
+    "mutators": [{ "handler": "noop" }]
+  },
+  {
+    "id": "api-test",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api-test",
+      "url": "http://api:8080"
+    },
+    "match": {
+      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api-test/(?!health|public).*>",
+      "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    },
+    "authenticators": [
+      {
+        "handler": "cookie_session",
+        "config": {
+          "check_session_url": "http://kratos:4433/sessions/whoami",
+          "preserve_path": true,
+          "extra_from": "@this",
+          "subject_from": "identity.id"
+        }
+      },
+      { "handler": "oauth2_introspection" }
+    ],
+    "authorizer": {
+      "handler": "remote_json",
+      "config": {
+        "remote": "http://keto:4466/relation-tuples/check",
+        "payload": "{\"namespace\":\"App\",\"object\":\"nova-id-test-app\",\"relation\":\"access\",\"subject_id\":\"user:{{ print .Subject }}\"}",
+        "forward_response_headers_to_upstream": ["Content-Type"]
+      }
+    },
+    "mutators": [{ "handler": "id_token" }]
   }
 ]

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -243,7 +243,7 @@
       "url": "http://hydra:4444"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/\\.well-known/(openid-configuration|jwks\\.json).*>",
+      "url": "<(http|https)://(id\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/\\.well-known/(openid-configuration|jwks\\.json)>",
       "methods": ["GET", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -258,7 +258,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api-test/(health|public)>",
+      "url": "<(http|https)://(app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api-test/(health|public)>",
       "methods": ["GET", "OPTIONS"]
     },
     "authenticators": [{ "handler": "noop" }],
@@ -273,7 +273,7 @@
       "url": "http://api:8080"
     },
     "match": {
-      "url": "<(http|https)://(id\\.cativo\\.dev|auth\\.cativo\\.dev|admin\\.cativo\\.dev|app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api-test/(?!health|public).*>",
+      "url": "<(http|https)://(app\\.cativo\\.dev|oathkeeper(:[0-9]+)?)/api-test/(?!health|public).*>",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "authenticators": [

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -396,6 +396,43 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Demo relying-party — the living proof of the IdP. A full OAuth2/OIDC client
+  # (public + PKCE) that runs "Login with Nova ID" against id.cativo.dev and calls
+  # a sample resource server under /api-test/*. nginx proxies /api/* and /api-test/*
+  # to Oathkeeper (same-origin), so no browser CORS to the gateway is needed.
+  frontend-app:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend.prod
+      args:
+        SPA: frontend-app
+        # API base — same-origin: nginx proxy_pass /api/* → oathkeeper:4455.
+        VITE_OATHKEEPER_URL: /api
+        # Public origin of this app — drives the OAuth redirect_uri
+        # (`${VITE_APP_URL}/callback`, see Home.vue / useHydraOAuth.ts). MUST match
+        # the redirect_uris registered on the Hydra client.
+        VITE_APP_URL: "https://app.cativo.dev"
+        # OAuth2 client_id registered in Hydra (public client, PKCE, no secret).
+        VITE_NOVA_ID_CLIENT_ID: "nova-id-test-app"
+        # VITE_HYDRA_PUBLIC_URL intentionally omitted: useHydraOAuth.ts falls back to
+        # `${origin}/api/hydra-public` for non-.ory.localhost hosts, which routes via
+        # this nginx /api/* → oathkeeper hydra-public rule. Same for VITE_API_TEST_URL
+        # (defaults to `${origin}/api-test`).
+    networks:
+      - apps
+      - web
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=space-server_web"
+      - "traefik.http.routers.frontend-app.rule=Host(`app.cativo.dev`)"
+      - "traefik.http.routers.frontend-app.entrypoints=websecure"
+      - "traefik.http.routers.frontend-app.tls.certresolver=letsencryptresolver"
+      - "traefik.http.services.frontend-app.loadbalancer.server.port=80"
+    depends_on:
+      oathkeeper:
+        condition: service_healthy
+    restart: unless-stopped
+
 # ── Volumes ───────────────────────────────────────────────────────────────────
 
 volumes:

--- a/frontend-app/src/views/Architecture.vue
+++ b/frontend-app/src/views/Architecture.vue
@@ -23,6 +23,10 @@
           NOVA ID – Full Architecture
         </h1>
         <p class="text-cyber-muted font-mono text-sm tracking-wider">Identity Provider + Zero Trust Gateway for N Systems</p>
+        <p class="mt-2 text-xs font-mono text-tokyo-green/80">
+          <span class="text-tokyo-green">● Live today:</span> auth · admin · app (this demo) · id (gateway) — all on *.cativo.dev behind Traefik (LE TLS).
+          <span class="text-tokyo-light/50">Blog / Shop / CRM / mobile below are illustrative roadmap examples.</span>
+        </p>
       </div>
 
       <!-- Diagram -->
@@ -50,6 +54,17 @@
             <div class="rounded-lg border border-dashed border-tokyo-light/25 bg-tokyo-bg/80 px-3 py-2 text-center min-w-[100px]">
               <span class="block font-medium text-tokyo-light/50 text-xs sm:text-sm">+ more</span>
               <span class="block text-[10px] text-tokyo-light/40 mt-0.5">SPAs, mobile, etc.</span>
+            </div>
+          </div>
+          <div class="flex justify-center mb-2">
+            <svg class="w-6 h-8 text-tokyo-accent/60 animate-pulse-soft" fill="none" viewBox="0 0 24 32" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v24M8 20l4 4 4-4" />
+            </svg>
+          </div>
+          <div class="flex justify-center mb-2">
+            <div class="rounded-lg border-2 border-tokyo-accent/60 bg-tokyo-accent/10 px-4 py-3 text-center min-w-[200px] max-w-[320px] shadow-neon-cyan animate-glow-pulse">
+              <span class="block font-semibold text-tokyo-accent text-sm sm:text-base">Traefik</span>
+              <span class="block text-xs text-tokyo-light/60 mt-0.5 font-mono">Public TLS ingress · routes *.cativo.dev · Let's Encrypt</span>
             </div>
           </div>
           <div class="flex justify-center mb-2">
@@ -108,7 +123,8 @@
               <span class="block text-[10px] text-tokyo-light/60 mt-0.5">RBAC</span>
             </div>
             <div class="rounded-lg border border-tokyo-light/20 bg-tokyo-dark/90 px-3 py-2 text-center min-w-[90px]">
-              <span class="block font-semibold text-tokyo-light/70 text-xs sm:text-sm">AppRegistry</span>
+              <span class="block font-semibold text-tokyo-light/70 text-xs sm:text-sm">NestJS BFF</span>
+              <span class="block text-[10px] text-tokyo-light/50 mt-0.5">ADR-0006</span>
             </div>
           </div>
           <p class="text-center text-xs text-cyber-muted font-mono tracking-wider">
@@ -120,10 +136,14 @@
       <!-- Layer 1: Clients/Users -->
       <div class="mb-6 opacity-0 animate-fade-in-up" style="animation-delay: 220ms; animation-fill-mode: forwards">
         <div class="arch-card bg-tokyo-storm/80 border border-tokyo-accent/35 rounded-xl p-6 backdrop-blur-sm hover:border-tokyo-accent/55 hover:shadow-glow transition-all duration-300">
-          <h2 class="text-xl font-bold mb-4 flex items-center gap-2 font-mono tracking-wide">
+          <h2 class="text-xl font-bold mb-1 flex items-center gap-2 font-mono tracking-wide">
             <GlobeIcon class="w-6 h-6 text-tokyo-accent shrink-0" />
             <span class="text-tokyo-accent">Layer 1:</span> Clients / External Applications
           </h2>
+          <p class="text-xs font-mono text-tokyo-light/50 mb-4">
+            <span class="inline-block px-1.5 py-0.5 rounded bg-tokyo-accent/10 border border-tokyo-accent/25 text-tokyo-accent/70 mr-1">Illustrative</span>
+            The IdP supports these client types; only the Demo App (app.cativo.dev) is deployed today.
+          </p>
           <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div class="bg-tokyo-dark/70 rounded-lg p-4 border border-tokyo-accent/35 hover:border-tokyo-accent/55 hover:shadow-neon-cyan/50 transition-all duration-200">
               <div class="flex items-center gap-2 mb-3">
@@ -200,7 +220,7 @@
                     <ZapIcon class="w-5 h-5 text-tokyo-yellow shrink-0" />
                     <h4 class="font-bold text-tokyo-light">Oathkeeper (Gateway)</h4>
                   </div>
-                  <div class="text-xs text-cyber-muted mb-2 font-mono">api.cativo.dev – Single public entry point</div>
+                  <div class="text-xs text-cyber-muted mb-2 font-mono">id.cativo.dev – Single API gateway / Policy Enforcement Point (PEP)</div>
                   <div class="text-xs space-y-1">
                     <div class="text-tokyo-green">✓ Validates OAuth tokens</div>
                     <div class="text-tokyo-green">✓ Validates Kratos sessions</div>
@@ -254,15 +274,15 @@
                   <div class="text-xs text-cyber-muted">Authorization (ReBAC)</div>
                 </div>
                 <div class="bg-tokyo-dark rounded-lg p-3 border border-tokyo-light/15 hover:border-tokyo-light/30 transition-all duration-200 font-mono text-sm">
-                  <div class="font-semibold mb-1 text-tokyo-light">AppRegistry Service</div>
-                  <div class="text-xs text-cyber-muted">System Management API</div>
+                  <div class="font-semibold mb-1 text-tokyo-light">NestJS BFF</div>
+                  <div class="text-xs text-cyber-muted">IdP consolidation API (ADR-0006) · /api/v1/*</div>
                 </div>
                 <div class="bg-tokyo-dark rounded-lg p-3 border border-tokyo-light/15 hover:border-tokyo-light/30 transition-all duration-200 font-mono text-sm">
                   <div class="flex items-center gap-2">
                     <DatabaseIcon class="w-4 h-4 text-tokyo-light/70 shrink-0" />
                     <div class="font-semibold">PostgreSQL</div>
                   </div>
-                  <div class="text-xs text-cyber-muted">Kratos + Hydra + Keto + AppRegistry</div>
+                  <div class="text-xs text-cyber-muted">Kratos + Hydra + Keto (shared) + audit store</div>
                 </div>
               </div>
             </div>
@@ -385,22 +405,25 @@
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div class="bg-tokyo-dark/80 rounded-lg p-4 border border-tokyo-red/45 hover:border-tokyo-red/65 transition-all duration-200">
             <div class="font-semibold mb-2 text-tokyo-red font-mono">🌐 Public network</div>
-            <div class="text-xs text-tokyo-light/80 font-mono">Only Oathkeeper exposed (port 4455)</div>
+            <div class="text-xs text-tokyo-light/80 space-y-1 font-mono">
+              <div>• Traefik only (TLS terminator)</div>
+              <div>• Routes *.cativo.dev → SPA nginx + Oathkeeper</div>
+              <div>• All backends stay private</div>
+            </div>
           </div>
           <div class="bg-tokyo-dark/80 rounded-lg p-4 border border-tokyo-yellow/45 hover:border-tokyo-yellow/65 transition-all duration-200">
             <div class="font-semibold mb-2 text-tokyo-yellow font-mono">🔒 Apps network</div>
             <div class="text-xs text-tokyo-light/80 space-y-1 font-mono">
-              <div>• Oathkeeper</div>
-              <div>• Application backends (APIs &amp; microservices)</div>
-              <div>• Frontends</div>
+              <div>• Oathkeeper (PEP)</div>
+              <div>• NestJS BFF (ADR-0006)</div>
+              <div>• SPA nginx containers (auth / admin / app)</div>
             </div>
           </div>
           <div class="bg-tokyo-dark/80 rounded-lg p-4 border border-tokyo-accent-2/45 hover:border-tokyo-accent-2/65 transition-all duration-200">
             <div class="font-semibold mb-2 text-tokyo-accent-2 font-mono">🛡️ Ory internal network</div>
             <div class="text-xs text-tokyo-light/80 space-y-1 font-mono">
               <div>• Kratos, Hydra, Keto</div>
-              <div>• PostgreSQL</div>
-              <div>• AppRegistry</div>
+              <div>• PostgreSQL 15</div>
             </div>
           </div>
         </div>
@@ -424,11 +447,11 @@
             <div class="space-y-2 text-sm font-mono">
               <div class="flex items-start gap-2">
                 <span class="text-tokyo-green mt-1">1.</span>
-                <span class="text-tokyo-light/80">Register in AppRegistry (1 API call)</span>
+                <span class="text-tokyo-light/80">Register the app via the NestJS BFF onboarding (ADR-0006)</span>
               </div>
               <div class="flex items-start gap-2">
                 <span class="text-tokyo-green mt-1">2.</span>
-                <span class="text-tokyo-light/80">Get OAuth Client ID/Secret</span>
+                <span class="text-tokyo-light/80">Get an OAuth2 client (public + PKCE, no secret for SPAs)</span>
               </div>
               <div class="flex items-start gap-2">
                 <span class="text-tokyo-green mt-1">3.</span>
@@ -496,25 +519,25 @@ const badgeGreen = 'bg-tokyo-green text-tokyo-bg';
 const badgeYellow = 'bg-tokyo-yellow text-tokyo-bg';
 
 const loginFlowSteps = [
-  { step: 1, badgeClass: badgeCyan, text: 'User → Blog App → Click "Login with Nova ID"' },
-  { step: 2, badgeClass: badgeCyan, text: 'Redirect → auth.cativo.dev/oauth2/auth' },
-  { step: 3, badgeClass: badgePurple, text: 'Hydra → Kratos login screen' },
+  { step: 1, badgeClass: badgeCyan, text: 'User on Demo App (app.cativo.dev) clicks "Login with Nova ID"' },
+  { step: 2, badgeClass: badgeCyan, text: 'Redirect → id.cativo.dev/oauth2/auth (public client, PKCE S256, openid profile email offline_access)' },
+  { step: 3, badgeClass: badgePurple, text: 'Hydra delegates to Kratos login UI at auth.cativo.dev' },
   { step: 4, badgeClass: badgePurple, text: 'User enters credentials' },
-  { step: 5, badgeClass: badgePurple, text: 'Consent screen (permissions)' },
-  { step: 6, badgeClass: badgeGreen, text: 'Hydra → authorization code' },
-  { step: 7, badgeClass: badgeGreen, text: 'Blog App → exchange code for token' },
+  { step: 5, badgeClass: badgePurple, text: 'Consent skipped (demo client pre-approved)' },
+  { step: 6, badgeClass: badgeGreen, text: 'Hydra issues authorization code → app.cativo.dev/callback' },
+  { step: 7, badgeClass: badgeGreen, text: 'Demo App exchanges code + PKCE verifier for tokens at id.cativo.dev/oauth2/token' },
   { step: 8, badgeClass: badgeGreen, text: 'User logged in ✅' },
 ];
 
 const apiFlowSteps = [
-  { step: 1, badgeClass: badgeCyan, text: 'Blog App → GET /api/posts (Bearer token)' },
-  { step: 2, badgeClass: badgeYellow, text: 'Oathkeeper validates token with Hydra' },
-  { step: 3, badgeClass: badgeYellow, text: 'Oathkeeper checks permissions (Keto)' },
-  { step: 4, badgeClass: badgeYellow, text: 'Oathkeeper injects headers' },
-  { step: 5, badgeClass: badgeGreen, text: 'Forward → Blog API (with headers)' },
-  { step: 6, badgeClass: badgeGreen, text: 'Blog API trusts X-User-ID' },
-  { step: 7, badgeClass: badgeGreen, text: 'Blog API applies business logic' },
-  { step: 8, badgeClass: badgeGreen, text: 'Response → Blog App ✅' },
+  { step: 1, badgeClass: badgeCyan, text: 'Demo App calls protected resource via same-origin nginx (/api-test/*)' },
+  { step: 2, badgeClass: badgeYellow, text: 'Oathkeeper authenticates (Kratos cookie session OR OAuth2 introspection)' },
+  { step: 3, badgeClass: badgeYellow, text: 'Oathkeeper checks Keto permission (App:nova-id-test-app#access)' },
+  { step: 4, badgeClass: badgeYellow, text: 'Oathkeeper injects signed id_token / trusted headers' },
+  { step: 5, badgeClass: badgeGreen, text: 'Forward → NestJS demo API' },
+  { step: 6, badgeClass: badgeGreen, text: 'API trusts gateway-injected identity (no token re-validation)' },
+  { step: 7, badgeClass: badgeGreen, text: 'API applies business logic' },
+  { step: 8, badgeClass: badgeGreen, text: 'Response → Demo App ✅' },
 ];
 
 // Inline icon components (no external deps)


### PR DESCRIPTION
## What

Enables `frontend-app` as a **complete OAuth2/OIDC relying-party** at `app.cativo.dev` — the living proof of the IdP — and rewrites the `/architecture` page to faithfully reflect the real production deployment.

## Changes

**Infra (deploy the RP)**
- `frontend-app` service in `docker-compose.production.yml` (Traefik `Host(app.cativo.dev)`, LE TLS, `apps`+`web` nets, depends_on oathkeeper healthy)
- `Dockerfile.frontend.prod`: `VITE_APP_URL` + `VITE_NOVA_ID_CLIENT_ID` build-args (public client, PKCE, no secret)
- `spa.conf.template`: `/api-test/` proxy to oathkeeper — **inert for auth/admin** (oathkeeper rules are host-scoped)
- `rules.production.json`: `app.cativo.dev` added to public rules + new `api-test-public`/`api-test` (Keto `App:nova-id-test-app#access` gate) + bare `/.well-known` OIDC discovery
- CORS: `app.cativo.dev` on oathkeeper + hydra **public** ports only (admin `:4445` left tight)

**API**
- `DemoSeedService` gated off when `NODE_ENV=production` (no more `*.nova.test` not-found noise)

**Frontend**
- `/architecture` rewritten: `id.cativo.dev` gateway/issuer, NestJS BFF (ADR-0006) replaces "AppRegistry", Traefik ingress layer added, Blog/Shop/CRM reframed as roadmap examples, accurate login + protected-API flows

## Engineering decisions (verified, not assumed)
- **Keto gate**: live OPL has `permits.access = members.includes(subject)`; seeding `App:nova-id-test-app#members` resolves `access` (verified against running Keto). No OPL change.
- **`/api-test` routing**: prod SPA nginx only proxies `/api/`; the demo calls `/api-test/*`. Added a shared `/api-test/` proxy block (host-scoped at oathkeeper → inert for non-app SPAs).
- **CORS moot but consistent**: same-origin `/api` model means CORS isn't strictly needed, but added `app.cativo.dev` to match the existing belt-and-suspenders pattern for the other SPA origins.

## Deploy / verify (post-merge, separate step)
Register the Hydra client (redirect `https://app.cativo.dev/callback`, public+PKCE), seed Keto `App:nova-id-test-app#members@user:<prod-identity>`, rebuild `frontend-app` + restart oathkeeper, then browser E2E of the full OIDC flow. Tag `v1.1.0` after.

CI `build-prod-images` gate validates the `frontend-app` prod build.