### PR TITLE
fix(demo): prod schema init + data volume for demo roles store

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,10 @@
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/audit/audit.datasource.ts",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d src/audit/audit.datasource.ts",
     "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/audit/audit.datasource.ts",
-    "migration:show": "typeorm-ts-node-commonjs migration:show -d src/audit/audit.datasource.ts"
+    "migration:show": "typeorm-ts-node-commonjs migration:show -d src/audit/audit.datasource.ts",
+    "migration:run:demo": "typeorm-ts-node-commonjs migration:run -d src/demo/data-source.ts",
+    "migration:revert:demo": "typeorm-ts-node-commonjs migration:revert -d src/demo/data-source.ts",
+    "migration:show:demo": "typeorm-ts-node-commonjs migration:show -d src/demo/data-source.ts"
   },
   "engines": {
     "node": ">=22"

--- a/api/src/demo/data-source.ts
+++ b/api/src/demo/data-source.ts
@@ -1,0 +1,29 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { UserRole } from './roles/entities/user-role.entity';
+import { InitUserRoles1750000000000 } from './migrations/1750000000000-InitUserRoles';
+
+/**
+ * Standalone DataSource used exclusively by the TypeORM CLI (migration:run,
+ * migration:revert, migration:show for the demo SQLite store). It is NOT
+ * imported by the NestJS app module — the app uses TypeOrmModule.forRoot()
+ * in DemoModule.
+ *
+ * Connection parameters mirror demo.module.ts exactly: reads DEMO_DB_PATH
+ * from env or falls back to data/app_roles.db.
+ *
+ * Required export name: "default" — TypeORM CLI requires a default export.
+ */
+const AppRolesDataSource = new DataSource({
+  type: 'sqlite',
+  database: process.env.DEMO_DB_PATH ?? 'data/app_roles.db',
+  entities: [UserRole],
+  migrations: [InitUserRoles1750000000000],
+  /**
+   * synchronize MUST be false here. This DataSource is for migrations only;
+   * auto-sync would race with (and potentially corrupt) the migration state.
+   */
+  synchronize: false,
+});
+
+export default AppRolesDataSource;

--- a/api/src/demo/demo.module.ts
+++ b/api/src/demo/demo.module.ts
@@ -8,19 +8,24 @@ import { DemoController } from './demo.controller';
 import { DemoService } from './demo.service';
 import { DemoSeedService } from './demo-seed.service';
 import { UserRole } from './roles/entities/user-role.entity';
+import { InitUserRoles1750000000000 } from './migrations/1750000000000-InitUserRoles';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
       type: 'sqlite',
-      database: 'data/app_roles.db',
+      database: process.env.DEMO_DB_PATH ?? 'data/app_roles.db',
       entities: [UserRole],
+      migrations: [InitUserRoles1750000000000],
+      // migrationsRun: true ensures the user_roles table is created on startup
+      // in production where synchronize is OFF. In development, synchronize
+      // remains active as a convenience (ADR-0001 rationale unchanged).
+      migrationsRun: true,
       // synchronize is intentionally left enabled for non-production here.
       // Rationale (ADR-0001): the demo SQLite DB is ephemeral and dev/demo-only;
-      // it is never deployed to production. Auto-sync is harmless on a local,
-      // disposable file-based DB and avoids the overhead of maintaining SQLite
-      // migrations for a module that exists only to support local demos.
-      // If this module is ever promoted to a real environment, migrate it properly.
+      // Auto-sync is harmless on a local, disposable file-based DB and avoids
+      // the overhead of maintaining SQLite migrations for local dev workflow.
+      // In production (NODE_ENV=production), migrationsRun handles schema init.
       synchronize: process.env.NODE_ENV !== 'production',
     }),
     RolesModule,

--- a/api/src/demo/migrations/1750000000000-InitUserRoles.ts
+++ b/api/src/demo/migrations/1750000000000-InitUserRoles.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the user_roles table for the demo SQLite store.
+ *
+ * SQLite dialect — all column types are SQLite-native (TEXT, DATETIME).
+ * IF NOT EXISTS makes the migration idempotent: safe to run against a DB that
+ * was previously created by synchronize (local dev) and is now being promoted
+ * without a clean slate.
+ *
+ * Column mapping (entity → DDL):
+ *   userId     → TEXT PRIMARY KEY (varchar PrimaryColumn, length 255)
+ *   appRole    → TEXT NOT NULL DEFAULT 'app_user' (varchar Column, length 50)
+ *   createdAt  → DATETIME NOT NULL DEFAULT (datetime('now')) (CreateDateColumn)
+ *   updatedAt  → DATETIME NOT NULL DEFAULT (datetime('now')) (UpdateDateColumn)
+ */
+export class InitUserRoles1750000000000 implements MigrationInterface {
+  name = 'InitUserRoles1750000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "user_roles" (
+        "userId"    TEXT NOT NULL,
+        "appRole"   TEXT NOT NULL DEFAULT 'app_user',
+        "createdAt" DATETIME NOT NULL DEFAULT (datetime('now')),
+        "updatedAt" DATETIME NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY ("userId")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "user_roles"`);
+  }
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -293,8 +293,12 @@ services:
     command: ["node", "dist/main"]
     # No source bind-mount. No anonymous /app/node_modules.
     # api_logs provides persistent log retention across restarts.
+    # api_demo_data persists the SQLite demo roles store (app_roles.db)
+    # across container recreates — without this, role grants granted in
+    # production would be lost on every `docker compose up --force-recreate`.
     volumes:
       - api_logs:/app/logs
+      - api_demo_data:/app/data
     env_file:
       - .env.production
     environment:
@@ -439,6 +443,8 @@ volumes:
   postgres_data:
     driver: local
   api_logs:
+    driver: local
+  api_demo_data:
     driver: local
 
 # ── Networks ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

In production, `synchronize` is OFF for the demo SQLite TypeORM connection (`synchronize: process.env.NODE_ENV !== 'production'`), so the `user_roles` table is never created. `GET /api-test/me` calls `getAppRole()` → `findOne` on `user_roles` → throws \"no such table: user_roles\" → 500.

Additionally, `data/app_roles.db` lived in the container's writable layer, so any role grants were lost on every container recreate.

## Fix

### Migration
- `api/src/demo/migrations/1750000000000-InitUserRoles.ts` — creates `user_roles` with correct SQLite DDL matching the entity; `IF NOT EXISTS` makes it idempotent (safe against DBs previously created by `synchronize`)
- `api/src/demo/data-source.ts` — TypeORM CLI DataSource for the SQLite demo store, reads `DEMO_DB_PATH` from env or defaults to `data/app_roles.db`
- `demo.module.ts` — adds `migrations`, `migrationsRun: true` and `DEMO_DB_PATH` env var support so the table is created on startup in production
- `package.json` — adds `migration:run:demo`, `migration:revert:demo`, `migration:show:demo` scripts following the same pattern as the audit scripts

### Volume
- `docker-compose.production.yml` — adds `api_demo_data` named volume mounted to `/app/data`, persisting `app_roles.db` across container recreates

## Verification
- Build: `nest build` passes with zero TypeScript errors ✓
- Tests: 85/85 pass across 13 test suites ✓
- Migration run: `user_roles` table created with correct schema (verified via sqlite3 node API against `/tmp/test_roles.db`) ✓

## No regression
- Local dev: `synchronize: true` still active (`NODE_ENV !== 'production'`), no behavior change
- Audit Postgres datasource: untouched
- `migrationsRun: true` in dev is harmless — TypeORM records the migration as already applied after sync created the table