### PR TITLE
fix(demo-api): log API-explorer calls in access logs

### DIFF
--- a/demo-api/src/demo/demo.controller.ts
+++ b/demo-api/src/demo/demo.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller, Get, Post, Put, Delete, Body, Param, UseGuards, UseInterceptors,
 } from '@nestjs/common';
 import { LoggingInterceptor } from './logging.interceptor';
+import { LogAccess } from './log-access.decorator';
 import { DemoService } from './demo.service';
 import { RolesService } from './roles/roles.service';
 import { GetUser } from '../decorators/get-user.decorator';
@@ -15,6 +16,7 @@ import { DemoConfigureDto } from './dto/demo-configure.dto';
 import { DemoUpdateDataDto } from './dto/demo-update-data.dto';
 
 @Controller()
+@LogAccess()
 @UseInterceptors(LoggingInterceptor)
 export class DemoController {
   constructor(


### PR DESCRIPTION
## What was broken

`DemoController` handles all the API-explorer endpoints (`/me`, `/protected`, `/data`, etc.) but was missing the `@LogAccess()` decorator that `LoggingInterceptor` checks before recording a request. As a result, none of those calls ever appeared in the "Access logs" feature.

## Fix

Added `@LogAccess()` to `DemoController` (one import + one decorator). Mirrors the pattern already in `RolesController`.

## Tests

All 5 test suites pass (24 tests). The existing `"skips logging when @LogAccess is not set"` test in `logging.interceptor.spec.ts` is unaffected — it constructs its own handler context independent of `DemoController`.

Note: `npm run lint` always fails in demo-api due to a pre-existing missing `.eslintrc.js` (never committed — confirmed via `git log`). Not introduced by this change.

https://claude.ai/code/session_01PszuPmkLkeDUv8Ycp2rscs