### PR TITLE
fix(admin): route OAuth2-client CRUD through the BFF

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -464,6 +464,192 @@
         ]
       }
     },
+    "/v1/admin/clients": {
+      "get": {
+        "operationId": "AdminClientsController_list",
+        "summary": "List all OAuth2 clients",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Array of OAuth2 clients"
+          },
+          "401": {
+            "description": "Missing or invalid Bearer id_token"
+          },
+          "403": {
+            "description": "Caller lacks Platform:nova#administer in Keto"
+          }
+        },
+        "tags": [
+          "admin"
+        ],
+        "security": [
+          {
+            "oathkeeper-id-token": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "AdminClientsController_create",
+        "summary": "Create a new OAuth2 client",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOauth2ClientDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OAuth2 client created"
+          },
+          "401": {
+            "description": "Missing or invalid Bearer id_token"
+          },
+          "403": {
+            "description": "Caller lacks Platform:nova#administer in Keto"
+          },
+          "422": {
+            "description": "Validation failed"
+          }
+        },
+        "tags": [
+          "admin"
+        ],
+        "security": [
+          {
+            "oathkeeper-id-token": []
+          }
+        ]
+      }
+    },
+    "/v1/admin/clients/{id}": {
+      "get": {
+        "operationId": "AdminClientsController_get",
+        "summary": "Get a single OAuth2 client by id",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth2 client"
+          },
+          "401": {
+            "description": "Missing or invalid Bearer id_token"
+          },
+          "403": {
+            "description": "Caller lacks Platform:nova#administer in Keto"
+          },
+          "404": {
+            "description": "Client not found"
+          }
+        },
+        "tags": [
+          "admin"
+        ],
+        "security": [
+          {
+            "oathkeeper-id-token": []
+          }
+        ]
+      },
+      "put": {
+        "operationId": "AdminClientsController_update",
+        "summary": "Replace an OAuth2 client (full update)",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOauth2ClientDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth2 client updated"
+          },
+          "401": {
+            "description": "Missing or invalid Bearer id_token"
+          },
+          "403": {
+            "description": "Caller lacks Platform:nova#administer in Keto"
+          },
+          "404": {
+            "description": "Client not found"
+          },
+          "422": {
+            "description": "Validation failed"
+          }
+        },
+        "tags": [
+          "admin"
+        ],
+        "security": [
+          {
+            "oathkeeper-id-token": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "AdminClientsController_remove",
+        "summary": "Delete an OAuth2 client",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Client deleted"
+          },
+          "401": {
+            "description": "Missing or invalid Bearer id_token"
+          },
+          "403": {
+            "description": "Caller lacks Platform:nova#administer in Keto"
+          },
+          "404": {
+            "description": "Client not found"
+          }
+        },
+        "tags": [
+          "admin"
+        ],
+        "security": [
+          {
+            "oathkeeper-id-token": []
+          }
+        ]
+      }
+    },
     "/v1/me/permissions": {
       "get": {
         "operationId": "MeController_permissions",
@@ -755,6 +941,86 @@
         "required": [
           "recovery_link"
         ]
+      },
+      "CreateOauth2ClientDto": {
+        "type": "object",
+        "properties": {
+          "client_name": {
+            "type": "string",
+            "description": "Human-readable name for the OAuth2 client"
+          },
+          "redirect_uris": {
+            "description": "Allowed redirect URIs for authorization code / implicit flows",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "grant_types": {
+            "description": "Allowed OAuth2 grant types (e.g. authorization_code, client_credentials)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "response_types": {
+            "description": "Allowed response types (e.g. code, token, id_token)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scope": {
+            "type": "string",
+            "description": "Space-separated list of requested scopes"
+          },
+          "token_endpoint_auth_method": {
+            "type": "string",
+            "description": "Token endpoint authentication method (e.g. client_secret_basic, none)"
+          }
+        },
+        "required": [
+          "client_name",
+          "redirect_uris"
+        ]
+      },
+      "UpdateOauth2ClientDto": {
+        "type": "object",
+        "properties": {
+          "client_name": {
+            "type": "string",
+            "description": "Human-readable name for the OAuth2 client"
+          },
+          "redirect_uris": {
+            "description": "Allowed redirect URIs for authorization code / implicit flows",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "grant_types": {
+            "description": "Allowed OAuth2 grant types (e.g. authorization_code, client_credentials)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "response_types": {
+            "description": "Allowed response types (e.g. code, token, id_token)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scope": {
+            "type": "string",
+            "description": "Space-separated list of requested scopes"
+          },
+          "token_endpoint_auth_method": {
+            "type": "string",
+            "description": "Token endpoint authentication method (e.g. client_secret_basic, none)"
+          }
+        }
       },
       "PermissionsResponseDto": {
         "type": "object",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -957,17 +957,25 @@
             }
           },
           "grant_types": {
-            "description": "Allowed OAuth2 grant types (e.g. authorization_code, client_credentials)",
             "type": "array",
+            "description": "Allowed OAuth2 grant types",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "authorization_code",
+                "client_credentials",
+                "refresh_token"
+              ]
             }
           },
           "response_types": {
-            "description": "Allowed response types (e.g. code, token, id_token)",
             "type": "array",
+            "description": "Allowed response types",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "code"
+              ]
             }
           },
           "scope": {
@@ -976,7 +984,12 @@
           },
           "token_endpoint_auth_method": {
             "type": "string",
-            "description": "Token endpoint authentication method (e.g. client_secret_basic, none)"
+            "enum": [
+              "client_secret_basic",
+              "client_secret_post",
+              "none"
+            ],
+            "description": "Token endpoint authentication method"
           }
         },
         "required": [
@@ -999,17 +1012,25 @@
             }
           },
           "grant_types": {
-            "description": "Allowed OAuth2 grant types (e.g. authorization_code, client_credentials)",
             "type": "array",
+            "description": "Allowed OAuth2 grant types",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "authorization_code",
+                "client_credentials",
+                "refresh_token"
+              ]
             }
           },
           "response_types": {
-            "description": "Allowed response types (e.g. code, token, id_token)",
             "type": "array",
+            "description": "Allowed response types",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "code"
+              ]
             }
           },
           "scope": {
@@ -1018,7 +1039,12 @@
           },
           "token_endpoint_auth_method": {
             "type": "string",
-            "description": "Token endpoint authentication method (e.g. client_secret_basic, none)"
+            "enum": [
+              "client_secret_basic",
+              "client_secret_post",
+              "none"
+            ],
+            "description": "Token endpoint authentication method"
           }
         }
       },

--- a/api/src/admin/admin-clients.controller.ts
+++ b/api/src/admin/admin-clients.controller.ts
@@ -56,7 +56,6 @@ export class AdminClientsController {
   }
 
   @Post()
-  @HttpCode(201)
   @ApiOperation({ summary: 'Create a new OAuth2 client' })
   @ApiResponse({ status: 201, description: 'OAuth2 client created' })
   @ApiResponse({ status: 401, description: 'Missing or invalid Bearer id_token' })

--- a/api/src/admin/admin-clients.controller.ts
+++ b/api/src/admin/admin-clients.controller.ts
@@ -1,0 +1,123 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { HydraService } from '../ory/hydra.service';
+import { PlatformAdministerGuard } from '../guards/platform-administer.guard';
+import { AuditService } from '../audit/audit.service';
+import { GetUser } from '../decorators/get-user.decorator';
+import { AuthenticatedUser } from '../common/types/authenticated-user';
+import { CreateOauth2ClientDto } from './dto/create-oauth2-client.dto';
+import { UpdateOauth2ClientDto } from './dto/update-oauth2-client.dto';
+import type { OAuth2Client } from '@ory/hydra-client';
+
+@ApiTags('admin')
+@ApiBearerAuth('oathkeeper-id-token')
+@UseGuards(PlatformAdministerGuard)
+@Controller({ path: 'admin/clients', version: '1' })
+export class AdminClientsController {
+  constructor(
+    private readonly hydra: HydraService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all OAuth2 clients' })
+  @ApiOkResponse({ description: 'Array of OAuth2 clients' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Bearer id_token' })
+  @ApiResponse({ status: 403, description: 'Caller lacks Platform:nova#administer in Keto' })
+  async list(): Promise<OAuth2Client[]> {
+    return this.hydra.listClients();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single OAuth2 client by id' })
+  @ApiOkResponse({ description: 'OAuth2 client' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Bearer id_token' })
+  @ApiResponse({ status: 403, description: 'Caller lacks Platform:nova#administer in Keto' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  async get(@Param('id') id: string): Promise<OAuth2Client> {
+    return this.hydra.getClient(id);
+  }
+
+  @Post()
+  @HttpCode(201)
+  @ApiOperation({ summary: 'Create a new OAuth2 client' })
+  @ApiResponse({ status: 201, description: 'OAuth2 client created' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Bearer id_token' })
+  @ApiResponse({ status: 403, description: 'Caller lacks Platform:nova#administer in Keto' })
+  @ApiResponse({ status: 422, description: 'Validation failed' })
+  async create(
+    @GetUser() actor: AuthenticatedUser,
+    @Body() dto: CreateOauth2ClientDto,
+  ): Promise<OAuth2Client> {
+    const result = await this.hydra.createClient(dto as OAuth2Client);
+    await this.audit.record({
+      actorId: actor.userId,
+      actorEmail: actor.email,
+      action: 'oauth2_client.create',
+      targetId: result.client_id ?? 'unknown',
+      targetType: 'oauth2_client',
+    });
+    return result;
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Replace an OAuth2 client (full update)' })
+  @ApiOkResponse({ description: 'OAuth2 client updated' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Bearer id_token' })
+  @ApiResponse({ status: 403, description: 'Caller lacks Platform:nova#administer in Keto' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  @ApiResponse({ status: 422, description: 'Validation failed' })
+  async update(
+    @GetUser() actor: AuthenticatedUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateOauth2ClientDto,
+  ): Promise<OAuth2Client> {
+    const result = await this.hydra.updateClient(id, dto as OAuth2Client);
+    await this.audit.record({
+      actorId: actor.userId,
+      actorEmail: actor.email,
+      action: 'oauth2_client.update',
+      targetId: id,
+      targetType: 'oauth2_client',
+    });
+    return result;
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Delete an OAuth2 client' })
+  @ApiNoContentResponse({ description: 'Client deleted' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Bearer id_token' })
+  @ApiResponse({ status: 403, description: 'Caller lacks Platform:nova#administer in Keto' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  async remove(
+    @GetUser() actor: AuthenticatedUser,
+    @Param('id') id: string,
+  ): Promise<void> {
+    await this.hydra.deleteClient(id);
+    await this.audit.record({
+      actorId: actor.userId,
+      actorEmail: actor.email,
+      action: 'oauth2_client.delete',
+      targetId: id,
+      targetType: 'oauth2_client',
+    });
+  }
+}

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { AdminUsersController } from './admin-users.controller';
+import { AdminClientsController } from './admin-clients.controller';
 import { PlatformManageUsersGuard } from '../guards/platform-manage-users.guard';
+import { PlatformAdministerGuard } from '../guards/platform-administer.guard';
 import { AuditModule } from '../audit/audit.module';
 
-// OryModule is @Global() — KratosAdminService and KetoService are available without a local import.
+// OryModule is @Global() — KratosAdminService, HydraService, and KetoService are available without a local import.
 @Module({
   imports: [AuditModule],
-  controllers: [AdminUsersController],
-  providers: [PlatformManageUsersGuard],
+  controllers: [AdminUsersController, AdminClientsController],
+  providers: [PlatformManageUsersGuard, PlatformAdministerGuard],
 })
 export class AdminModule {}

--- a/api/src/admin/dto/create-oauth2-client.dto.ts
+++ b/api/src/admin/dto/create-oauth2-client.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsOptional, IsString, MinLength } from 'class-validator';
+import { IsArray, IsIn, IsOptional, IsString, IsUrl, MinLength } from 'class-validator';
 
 export class CreateOauth2ClientDto {
   @ApiProperty({ description: 'Human-readable name for the OAuth2 client' })
@@ -12,25 +12,29 @@ export class CreateOauth2ClientDto {
     description: 'Allowed redirect URIs for authorization code / implicit flows',
   })
   @IsArray()
-  @IsString({ each: true })
+  @IsUrl({ require_tld: false, protocols: ['http', 'https'] }, { each: true })
   redirect_uris!: string[];
 
   @ApiPropertyOptional({
-    type: [String],
-    description: 'Allowed OAuth2 grant types (e.g. authorization_code, client_credentials)',
+    enum: ['authorization_code', 'client_credentials', 'refresh_token'],
+    isArray: true,
+    required: false,
+    description: 'Allowed OAuth2 grant types',
   })
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
+  @IsIn(['authorization_code', 'client_credentials', 'refresh_token'], { each: true })
   grant_types?: string[];
 
   @ApiPropertyOptional({
-    type: [String],
-    description: 'Allowed response types (e.g. code, token, id_token)',
+    enum: ['code'],
+    isArray: true,
+    required: false,
+    description: 'Allowed response types',
   })
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
+  @IsIn(['code'], { each: true })
   response_types?: string[];
 
   @ApiPropertyOptional({
@@ -41,9 +45,11 @@ export class CreateOauth2ClientDto {
   scope?: string;
 
   @ApiPropertyOptional({
-    description: 'Token endpoint authentication method (e.g. client_secret_basic, none)',
+    enum: ['client_secret_basic', 'client_secret_post', 'none'],
+    required: false,
+    description: 'Token endpoint authentication method',
   })
   @IsOptional()
-  @IsString()
+  @IsIn(['client_secret_basic', 'client_secret_post', 'none'])
   token_endpoint_auth_method?: string;
 }

--- a/api/src/admin/dto/create-oauth2-client.dto.ts
+++ b/api/src/admin/dto/create-oauth2-client.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class CreateOauth2ClientDto {
+  @ApiProperty({ description: 'Human-readable name for the OAuth2 client' })
+  @IsString()
+  @MinLength(1)
+  client_name!: string;
+
+  @ApiProperty({
+    type: [String],
+    description: 'Allowed redirect URIs for authorization code / implicit flows',
+  })
+  @IsArray()
+  @IsString({ each: true })
+  redirect_uris!: string[];
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Allowed OAuth2 grant types (e.g. authorization_code, client_credentials)',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  grant_types?: string[];
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Allowed response types (e.g. code, token, id_token)',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  response_types?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Space-separated list of requested scopes',
+  })
+  @IsOptional()
+  @IsString()
+  scope?: string;
+
+  @ApiPropertyOptional({
+    description: 'Token endpoint authentication method (e.g. client_secret_basic, none)',
+  })
+  @IsOptional()
+  @IsString()
+  token_endpoint_auth_method?: string;
+}

--- a/api/src/admin/dto/update-oauth2-client.dto.ts
+++ b/api/src/admin/dto/update-oauth2-client.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateOauth2ClientDto } from './create-oauth2-client.dto';
+
+export class UpdateOauth2ClientDto extends PartialType(CreateOauth2ClientDto) {}

--- a/api/src/guards/platform-administer.guard.spec.ts
+++ b/api/src/guards/platform-administer.guard.spec.ts
@@ -1,0 +1,30 @@
+import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { PlatformAdministerGuard } from './platform-administer.guard';
+
+function ctx(user: any): ExecutionContext {
+  return { switchToHttp: () => ({ getRequest: () => ({ user }) }) } as any;
+}
+
+describe('PlatformAdministerGuard', () => {
+  it('allows when KetoService.check(administer) is true', async () => {
+    const keto = { check: jest.fn().mockResolvedValue(true) };
+    const guard = new PlatformAdministerGuard(keto as any);
+    await expect(guard.canActivate(ctx({ userId: 'abc' }))).resolves.toBe(true);
+    expect(keto.check).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'Platform', object: 'nova', relation: 'administer', subjectId: 'user:abc' }),
+    );
+  });
+
+  it('denies (Forbidden) when Keto check is false', async () => {
+    const keto = { check: jest.fn().mockResolvedValue(false) };
+    const guard = new PlatformAdministerGuard(keto as any);
+    await expect(guard.canActivate(ctx({ userId: 'abc' }))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('throws UnauthorizedException (not Forbidden) when there is no authenticated user', async () => {
+    const keto = { check: jest.fn() };
+    const guard = new PlatformAdministerGuard(keto as any);
+    await expect(guard.canActivate(ctx(undefined))).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(keto.check).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/guards/platform-administer.guard.ts
+++ b/api/src/guards/platform-administer.guard.ts
@@ -1,0 +1,54 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { KetoService } from '../ory/keto.service';
+
+/**
+ * PlatformAdministerGuard — Keto permission gate for Platform:nova#administer.
+ *
+ * Protects endpoints that administer the platform (e.g. OAuth2 client CRUD).
+ * Requires the caller to hold the `administer` relation on the `Platform:nova`
+ * object in Keto.
+ *
+ * Fail-closed: any Keto error (service down, network failure) results in deny
+ * because KetoService.check() already returns false on error.
+ *
+ * Must be applied AFTER AuthenticatedGuard (which populates request.user).
+ */
+@Injectable()
+export class PlatformAdministerGuard implements CanActivate {
+  private readonly logger = new Logger(PlatformAdministerGuard.name);
+
+  constructor(private readonly keto: KetoService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId: string | undefined = request.user?.userId;
+
+    if (!userId) {
+      this.logger.warn('PlatformAdministerGuard: No authenticated user in request');
+      throw new UnauthorizedException('Authentication required');
+    }
+
+    const allowed = await this.keto.check({
+      namespace: 'Platform',
+      object: 'nova',
+      relation: 'administer',
+      subjectId: `user:${userId}`,
+    });
+
+    if (!allowed) {
+      this.logger.warn(
+        `PlatformAdministerGuard: User ${userId} denied — missing Platform:nova#administer`,
+      );
+      throw new ForbiddenException('Platform administer permission required');
+    }
+
+    return true;
+  }
+}

--- a/api/src/ory/hydra.service.ts
+++ b/api/src/ory/hydra.service.ts
@@ -7,6 +7,7 @@ import type {
   OAuth2LoginRequest,
   OAuth2ConsentRequest,
   RejectOAuth2Request,
+  OAuth2Client,
 } from '@ory/hydra-client';
 import { HYDRA_OAUTH2_API } from './ory.constants';
 
@@ -61,5 +62,29 @@ export class HydraService {
       rejectOAuth2Request: body,
     });
     return data;
+  }
+
+  async listClients(): Promise<OAuth2Client[]> {
+    const { data } = await this.oauth2Api.listOAuth2Clients({});
+    return data;
+  }
+
+  async getClient(id: string): Promise<OAuth2Client> {
+    const { data } = await this.oauth2Api.getOAuth2Client({ id });
+    return data;
+  }
+
+  async createClient(body: OAuth2Client): Promise<OAuth2Client> {
+    const { data } = await this.oauth2Api.createOAuth2Client({ oAuth2Client: body });
+    return data;
+  }
+
+  async updateClient(id: string, body: OAuth2Client): Promise<OAuth2Client> {
+    const { data } = await this.oauth2Api.setOAuth2Client({ id, oAuth2Client: body });
+    return data;
+  }
+
+  async deleteClient(id: string): Promise<void> {
+    await this.oauth2Api.deleteOAuth2Client({ id });
   }
 }

--- a/config/oathkeeper/rules.local.json
+++ b/config/oathkeeper/rules.local.json
@@ -150,51 +150,6 @@
     ]
   },
   {
-    "id": "hydra-admin",
-    "upstream": {
-      "preserve_host": false,
-      "strip_path": "/api/hydra-admin",
-      "url": "http://hydra:4445"
-    },
-    "match": {
-      "url": "<(http|https)://(api\\.ory\\.localhost|admin\\.ory\\.localhost|auth\\.ory\\.localhost|app\\.ory\\.localhost|localhost(:[0-9]+)?|oathkeeper(:[0-9]+)?)/api/hydra-admin/.*>",
-      "methods": [
-        "GET",
-        "POST",
-        "PUT",
-        "DELETE",
-        "PATCH",
-        "OPTIONS"
-      ]
-    },
-    "authenticators": [
-      {
-        "handler": "cookie_session"
-      }
-    ],
-    "authorizer": {
-      "handler": "remote_json",
-      "config": {
-        "remote": "http://keto:4466/relation-tuples/check",
-        "payload": "{\"namespace\":\"Platform\",\"object\":\"nova\",\"relation\":\"administer\",\"subject_id\":\"user:{{ print .Subject }}\"}",
-        "forward_response_headers_to_upstream": [
-          "Content-Type"
-        ]
-      }
-    },
-    "mutators": [
-      {
-        "handler": "header",
-        "config": {
-          "headers": {
-            "X-User-ID": "{{ print .Subject }}",
-            "X-User-Email": "{{ print .Extra.identity.traits.email }}"
-          }
-        }
-      }
-    ]
-  },
-  {
     "id": "frontend-auth",
     "upstream": {
       "preserve_host": false,

--- a/frontend-admin/src/composables/useHydra.ts
+++ b/frontend-admin/src/composables/useHydra.ts
@@ -1,11 +1,12 @@
 // Hydra API composable for OAuth2/OIDC client management
-// ZERO TRUST: Route through Oathkeeper - frontend cannot directly reach Hydra
-// NOTE: This is OUTSIDE the BFF surface (calls Hydra Admin via the gateway, not
-// the Nest BFF), so it intentionally keeps hand-rolled fetch — it is not part of
-// the generated @nova-id/api-client.
+// ZERO TRUST: Route through Oathkeeper + BFF - frontend cannot directly reach Hydra Admin
+// NOTE: These calls are routed through the NestJS BFF at /v1/admin/clients.
+// The BFF endpoints are gated by Keto Platform:nova#administer via PlatformAdministerGuard.
+// Hand-rolled fetch is kept here intentionally — this module is not part of the
+// generated @nova-id/api-client.
 import { logger, errMessage } from '../utils/logger'
 const oathkeeperUrl = import.meta.env.VITE_OATHKEEPER_URL || '/api'
-const hydraAdminUrl = `${oathkeeperUrl}/hydra-admin`
+const bffClientsUrl = `${oathkeeperUrl}/v1/admin/clients`
 
 /** Minimal OAuth2 client shape used by the UI. */
 export interface OAuthClient {
@@ -18,7 +19,7 @@ export interface OAuthClient {
 // List all OAuth clients
 export async function listClients(): Promise<OAuthClient[]> {
   try {
-    const response = await fetch(`${hydraAdminUrl}/clients`, {
+    const response = await fetch(`${bffClientsUrl}`, {
       method: 'GET',
       credentials: 'include',
       mode: 'cors',
@@ -42,7 +43,7 @@ export async function listClients(): Promise<OAuthClient[]> {
 // Get a single OAuth client
 export async function getClient(clientId: string): Promise<OAuthClient> {
   try {
-    const response = await fetch(`${hydraAdminUrl}/clients/${clientId}`, {
+    const response = await fetch(`${bffClientsUrl}/${clientId}`, {
       method: 'GET',
       credentials: 'include',
       mode: 'cors',
@@ -66,7 +67,7 @@ export async function getClient(clientId: string): Promise<OAuthClient> {
 // Create an OAuth client
 export async function createClient(clientData: Record<string, unknown>): Promise<OAuthClient> {
   try {
-    const response = await fetch(`${hydraAdminUrl}/clients`, {
+    const response = await fetch(`${bffClientsUrl}`, {
       method: 'POST',
       credentials: 'include',
       mode: 'cors',
@@ -92,7 +93,7 @@ export async function createClient(clientData: Record<string, unknown>): Promise
 // Update an OAuth client
 export async function updateClient(clientId: string, clientData: Record<string, unknown>): Promise<OAuthClient> {
   try {
-    const response = await fetch(`${hydraAdminUrl}/clients/${clientId}`, {
+    const response = await fetch(`${bffClientsUrl}/${clientId}`, {
       method: 'PUT',
       credentials: 'include',
       mode: 'cors',
@@ -118,7 +119,7 @@ export async function updateClient(clientId: string, clientData: Record<string, 
 // Delete an OAuth client
 export async function deleteClient(clientId: string): Promise<boolean> {
   try {
-    const response = await fetch(`${hydraAdminUrl}/clients/${clientId}`, {
+    const response = await fetch(`${bffClientsUrl}/${clientId}`, {
       method: 'DELETE',
       credentials: 'include',
       mode: 'cors',


### PR DESCRIPTION
## Summary

- **Bug**: `frontend-admin/src/composables/useHydra.ts` was calling `/api/hydra-admin/*` directly for OAuth2 client CRUD. In prod, `hydra-admin` (port 4445) is intentionally not exposed through the Oathkeeper gateway, so all OAuth-client management calls 404'd silently.
- **Fix**: Added 5 new BFF endpoints at `GET|POST /v1/admin/clients` and `GET|PUT|DELETE /v1/admin/clients/:id` in the NestJS BFF. Frontend composable updated to call `${oathkeeperUrl}/v1/admin/clients` instead.
- **Authz**: New `PlatformAdministerGuard` checks `Platform:nova#administer` in Keto — the same relation the existing `protected-admin` Oathkeeper rule already enforces at the gateway layer (defense in depth). This matches the intent of the old `hydra-admin` Oathkeeper rule which also checked `administer`.
- **Dead rule removed**: The `hydra-admin` rule in `config/oathkeeper/rules.local.json` (which never existed in `rules.production.json`) has been deleted — confirmed no other code references `/api/hydra-admin`.

## Changes

- `api/src/ory/hydra.service.ts` — 5 new methods: `listClients`, `getClient`, `createClient`, `updateClient`, `deleteClient`
- `api/src/guards/platform-administer.guard.ts` — new guard checking `administer` relation
- `api/src/guards/platform-administer.guard.spec.ts` — 3 passing tests
- `api/src/admin/dto/create-oauth2-client.dto.ts` + `update-oauth2-client.dto.ts` — validated DTOs
- `api/src/admin/admin-clients.controller.ts` — new controller with audit entries on writes
- `api/src/admin/admin.module.ts` — registers new controller + guard
- `frontend-admin/src/composables/useHydra.ts` — repoints all fetches to `/v1/admin/clients`
- `config/oathkeeper/rules.local.json` — removes dead `hydra-admin` rule
- `api/openapi.json` — regenerated; now includes `/v1/admin/clients` and `/v1/admin/clients/{id}`

## Test plan

- [x] `npm run build` — passes (EXIT:0)
- [x] `npm test -- --testPathPattern="platform-administer|admin-clients"` — 3/3 pass
- [x] `openapi.json` regenerated with 11 paths including `/v1/admin/clients` and `/v1/admin/clients/{id}`

https://claude.ai/code/session_01PszuPmkLkeDUv8Ycp2rscs