### PR TITLE
ci: release workflow — build, scan, push 5 images on v* tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,16 @@ jobs:
         run: npm test
 
   # ---------------------------------------------------------------------------
-  # Production Docker image build — verifies all three production Dockerfiles
-  # compile successfully. Build-only: no images are pushed or deployed.
+  # Production Docker image build — verifies all 5 production Dockerfiles compile
+  # successfully on every PR. Build-only: no images are pushed or deployed.
   # Trivy scan omitted: no registry push in CI, so scanning build-time artifacts
-  # adds runtime cost without actionable signal until B3 (CD) lands.
+  # adds runtime cost without actionable signal — release.yml scans on tag push.
+  #
+  # Direct `docker build` (NOT the prod compose) is used on purpose: after B3 the
+  # compose app services are `image:` refs with a fail-loud ${IMAGE_TAG:?...}, so
+  # `docker compose -f docker-compose.production.yml config/build` would error
+  # without a tag. This job builds the Dockerfiles directly with the SAME
+  # build-args release.yml bakes in — keep them in sync with release.yml.
   # ---------------------------------------------------------------------------
   build-prod-images:
     name: Build production images (build-only, no push)
@@ -222,21 +228,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # docker-compose.production.yml declares `env_file: [.env.production]` on every
-      # Ory service, and Compose v2 hard-errors when an env_file is missing. That file
-      # is gitignored (real secrets), so it's absent in CI. Build args (VITE_*) are
-      # literal in the compose file and env_file values are NOT used during `build`,
-      # so a placeholder stub from the committed template satisfies the existence check.
-      # env_file stays REQUIRED (not required:false) so production fails loudly on missing secrets.
-      - name: Stub .env.production for build (values irrelevant to build)
-        run: cp .env.production.example .env.production
-
-      # Validate the compose file is syntactically valid before attempting the build.
-      - name: Validate docker-compose.production.yml
-        run: docker compose -f docker-compose.production.yml config >/dev/null
-
-      # After B3: app services use image: refs (no build: context). The compose
-      # file is still validated above. Full image builds happen in release.yml.
-      # This step is now a no-op but kept to confirm the file is parse-valid.
-      - name: Validate compose build spec (no-op post-B3)
-        run: docker compose -f docker-compose.production.yml build --dry-run 2>/dev/null || true
+      # Real build gate: a broken Dockerfile or build-arg fails the PR here.
+      # Frontend build-args mirror .github/workflows/release.yml exactly.
+      - name: Build production images (CI gate — no push)
+        run: |
+          docker build -f api/Dockerfile -t nova-id-api:ci api/
+          docker build -f demo-api/Dockerfile -t nova-id-demo-api:ci demo-api/
+          docker build -f Dockerfile.frontend.prod \
+            --build-arg SPA=frontend-auth \
+            --build-arg VITE_OATHKEEPER_URL=/api \
+            --build-arg VITE_ALLOWED_REDIRECT_ORIGINS=https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev \
+            --build-arg VITE_DEFAULT_RETURN_URL=https://auth.cativo.dev \
+            -t nova-id-frontend-auth:ci .
+          docker build -f Dockerfile.frontend.prod \
+            --build-arg SPA=frontend-admin \
+            --build-arg VITE_OATHKEEPER_URL=/api \
+            --build-arg VITE_AUTH_UI_URL=https://auth.cativo.dev \
+            --build-arg VITE_KRATOS_BROWSER_URL=https://auth.cativo.dev/auth \
+            --build-arg VITE_ADMIN_URL=https://admin.cativo.dev \
+            -t nova-id-frontend-admin:ci .
+          docker build -f Dockerfile.frontend.prod \
+            --build-arg SPA=frontend-app \
+            --build-arg VITE_OATHKEEPER_URL=/api \
+            --build-arg VITE_APP_URL=https://app.cativo.dev \
+            --build-arg VITE_NOVA_ID_CLIENT_ID=nova-id-test-app \
+            --build-arg VITE_OAUTH_ISSUER=https://id.cativo.dev/ \
+            -t nova-id-frontend-app:ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,8 @@ jobs:
       - name: Validate docker-compose.production.yml
         run: docker compose -f docker-compose.production.yml config >/dev/null
 
-      # Build api (api/Dockerfile) + frontend-auth + frontend-admin
-      # (Dockerfile.frontend.prod with VITE build args). Runtime env_file entries
-      # are irrelevant to `build`; build args are declared inline in the compose file.
-      - name: Build production images
-        run: docker compose -f docker-compose.production.yml build
+      # After B3: app services use image: refs (no build: context). The compose
+      # file is still validated above. Full image builds happen in release.yml.
+      # This step is now a no-op but kept to confirm the file is parse-valid.
+      - name: Validate compose build spec (no-op post-B3)
+        run: docker compose -f docker-compose.production.yml build --dry-run 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,406 @@
+# .github/workflows/release.yml
+#
+# Triggered by push of a v* tag (e.g. v1.2.0) or workflow_dispatch with a
+# ref input (tag or sha — for surgical rollback redeploy).
+#
+# Builds 5 production Docker images, scans each with Trivy (fail on
+# CRITICAL or HIGH CVEs), then pushes to Docker Hub:
+#   cativo23/nova-id-api
+#   cativo23/nova-id-frontend-auth
+#   cativo23/nova-id-frontend-admin
+#   cativo23/nova-id-frontend-app
+#   cativo23/nova-id-demo-api
+#
+# Each image is tagged with the immutable version (:v1.2.0) and :latest.
+# deploy.yml subsequently pulls by immutable tag — never :latest.
+#
+# SECURITY: Images are PUBLIC on Docker Hub (free tier limit: 1 private).
+# HARD RULE: Never bake secrets into images. VITE_* build-args are
+# non-secret public URLs. .env.production and JWKS never enter images.
+
+name: Release — Build, Scan & Push
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or SHA to build (e.g. v1.2.0)'
+        required: true
+        default: ''
+
+# One release build at a time — prevent overlapping pushes on the same tag.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: docker.io
+  IMAGE_PREFIX: cativo23/nova-id
+
+jobs:
+  # ── API (NestJS BFF) ─────────────────────────────────────────────────────
+  build-api:
+    name: Build, Scan & Push — api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set image tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build api image (do not push yet — Trivy scans first)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./api
+          file: ./api/Dockerfile
+          push: false
+          load: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan — api (fail on CRITICAL or HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: '${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push api image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./api
+          file: ./api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Demo API ─────────────────────────────────────────────────────────────
+  build-demo-api:
+    name: Build, Scan & Push — demo-api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set image tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build demo-api image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./demo-api
+          file: ./demo-api/Dockerfile
+          push: false
+          load: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-demo-api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan — demo-api (fail on CRITICAL or HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: '${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push demo-api image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./demo-api
+          file: ./demo-api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-demo-api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── frontend-auth SPA ────────────────────────────────────────────────────
+  build-frontend-auth:
+    name: Build, Scan & Push — frontend-auth
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set image tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build frontend-auth image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend.prod
+          push: false
+          load: true
+          build-args: |
+            SPA=frontend-auth
+            VITE_OATHKEEPER_URL=/api
+            VITE_ALLOWED_REDIRECT_ORIGINS=https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev
+            VITE_DEFAULT_RETURN_URL=https://auth.cativo.dev
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-frontend-auth:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan — frontend-auth (fail on CRITICAL or HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: '${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push frontend-auth image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend.prod
+          push: true
+          build-args: |
+            SPA=frontend-auth
+            VITE_OATHKEEPER_URL=/api
+            VITE_ALLOWED_REDIRECT_ORIGINS=https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev
+            VITE_DEFAULT_RETURN_URL=https://auth.cativo.dev
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-frontend-auth:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── frontend-admin SPA ───────────────────────────────────────────────────
+  build-frontend-admin:
+    name: Build, Scan & Push — frontend-admin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set image tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build frontend-admin image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend.prod
+          push: false
+          load: true
+          build-args: |
+            SPA=frontend-admin
+            VITE_OATHKEEPER_URL=/api
+            VITE_AUTH_UI_URL=https://auth.cativo.dev
+            VITE_KRATOS_BROWSER_URL=https://auth.cativo.dev/auth
+            VITE_ADMIN_URL=https://admin.cativo.dev
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-frontend-admin:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan — frontend-admin (fail on CRITICAL or HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: '${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push frontend-admin image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend.prod
+          push: true
+          build-args: |
+            SPA=frontend-admin
+            VITE_OATHKEEPER_URL=/api
+            VITE_AUTH_UI_URL=https://auth.cativo.dev
+            VITE_KRATOS_BROWSER_URL=https://auth.cativo.dev/auth
+            VITE_ADMIN_URL=https://admin.cativo.dev
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-frontend-admin:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── frontend-app SPA (demo relying-party) ────────────────────────────────
+  build-frontend-app:
+    name: Build, Scan & Push — frontend-app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set image tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build frontend-app image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend.prod
+          push: false
+          load: true
+          build-args: |
+            SPA=frontend-app
+            VITE_OATHKEEPER_URL=/api
+            VITE_APP_URL=https://app.cativo.dev
+            VITE_NOVA_ID_CLIENT_ID=nova-id-test-app
+            VITE_OAUTH_ISSUER=https://id.cativo.dev/
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-frontend-app:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan — frontend-app (fail on CRITICAL or HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: '${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}'
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push frontend-app image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend.prod
+          push: true
+          build-args: |
+            SPA=frontend-app
+            VITE_OATHKEEPER_URL=/api
+            VITE_APP_URL=https://app.cativo.dev
+            VITE_NOVA_ID_CLIENT_ID=nova-id-test-app
+            VITE_OAUTH_ISSUER=https://id.cativo.dev/
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}-frontend-app:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,19 @@
 
 name: Release — Build, Scan & Push
 
+# Job topology: 5 flat, parallel jobs — one per image — deliberately NOT a matrix.
+# api and demo-api differ by build context AND Dockerfile. The 3 frontends share
+# Dockerfile.frontend.prod but differ only by build-args (SPA + VITE_*). A matrix
+# was considered and rejected: collapsing all 5 into one matrix would force a
+# single context/Dockerfile/build-arg shape, hurting readability and making the
+# per-image differences implicit. The duplication here is intentional and explicit.
+# Do not refactor to a matrix without a concrete reason.
+
+# Least privilege: this workflow only reads the repo and pushes to an external
+# registry (Docker Hub) via DOCKERHUB_* secrets. It never writes to GitHub.
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -72,7 +85,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build api image (do not push yet — Trivy scans first)
+      # Build once with load:true so Trivy scans the exact bytes we later push.
+      # No second build — the push step pushes this same local image.
+      - name: Build api image (load locally — Trivy scans before any push)
         uses: docker/build-push-action@v5
         with:
           context: ./api
@@ -80,32 +95,29 @@ jobs:
           push: false
           load: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-api:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-api:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy scan — api (fail on CRITICAL or HIGH)
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: '${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}'
           format: table
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
 
-      - name: Push api image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./api
-          file: ./api/Dockerfile
-          push: true
-          tags: |
-            ${{ env.IMAGE_PREFIX }}-api:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-api:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Push the already-built, already-scanned local image — no rebuild.
+      - name: Push scanned api image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-api
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          docker push "${IMAGE_REF}:${VERSION}"
+          docker push "${IMAGE_REF}:latest"
 
   # ── Demo API ─────────────────────────────────────────────────────────────
   build-demo-api:
@@ -138,7 +150,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build demo-api image
+      # Build once with load:true so Trivy scans the exact bytes we later push.
+      - name: Build demo-api image (load locally — Trivy scans before any push)
         uses: docker/build-push-action@v5
         with:
           context: ./demo-api
@@ -146,32 +159,29 @@ jobs:
           push: false
           load: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-demo-api:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-demo-api:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy scan — demo-api (fail on CRITICAL or HIGH)
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: '${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}'
           format: table
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
 
-      - name: Push demo-api image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./demo-api
-          file: ./demo-api/Dockerfile
-          push: true
-          tags: |
-            ${{ env.IMAGE_PREFIX }}-demo-api:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-demo-api:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Push the already-built, already-scanned local image — no rebuild.
+      - name: Push scanned demo-api image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-demo-api
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          docker push "${IMAGE_REF}:${VERSION}"
+          docker push "${IMAGE_REF}:latest"
 
   # ── frontend-auth SPA ────────────────────────────────────────────────────
   build-frontend-auth:
@@ -204,7 +214,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build frontend-auth image
+      # Build once with load:true so Trivy scans the exact bytes we later push.
+      - name: Build frontend-auth image (load locally — Trivy scans before any push)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -217,37 +228,29 @@ jobs:
             VITE_ALLOWED_REDIRECT_ORIGINS=https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev
             VITE_DEFAULT_RETURN_URL=https://auth.cativo.dev
           tags: |
-            ${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-frontend-auth:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-auth:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy scan — frontend-auth (fail on CRITICAL or HIGH)
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: '${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}'
           format: table
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
 
-      - name: Push frontend-auth image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.frontend.prod
-          push: true
-          build-args: |
-            SPA=frontend-auth
-            VITE_OATHKEEPER_URL=/api
-            VITE_ALLOWED_REDIRECT_ORIGINS=https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev
-            VITE_DEFAULT_RETURN_URL=https://auth.cativo.dev
-          tags: |
-            ${{ env.IMAGE_PREFIX }}-frontend-auth:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-frontend-auth:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Push the already-built, already-scanned local image — no rebuild.
+      - name: Push scanned frontend-auth image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-auth
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          docker push "${IMAGE_REF}:${VERSION}"
+          docker push "${IMAGE_REF}:latest"
 
   # ── frontend-admin SPA ───────────────────────────────────────────────────
   build-frontend-admin:
@@ -280,7 +283,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build frontend-admin image
+      # Build once with load:true so Trivy scans the exact bytes we later push.
+      - name: Build frontend-admin image (load locally — Trivy scans before any push)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -294,38 +298,29 @@ jobs:
             VITE_KRATOS_BROWSER_URL=https://auth.cativo.dev/auth
             VITE_ADMIN_URL=https://admin.cativo.dev
           tags: |
-            ${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-frontend-admin:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-admin:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy scan — frontend-admin (fail on CRITICAL or HIGH)
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: '${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}'
           format: table
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
 
-      - name: Push frontend-admin image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.frontend.prod
-          push: true
-          build-args: |
-            SPA=frontend-admin
-            VITE_OATHKEEPER_URL=/api
-            VITE_AUTH_UI_URL=https://auth.cativo.dev
-            VITE_KRATOS_BROWSER_URL=https://auth.cativo.dev/auth
-            VITE_ADMIN_URL=https://admin.cativo.dev
-          tags: |
-            ${{ env.IMAGE_PREFIX }}-frontend-admin:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-frontend-admin:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Push the already-built, already-scanned local image — no rebuild.
+      - name: Push scanned frontend-admin image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-admin
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          docker push "${IMAGE_REF}:${VERSION}"
+          docker push "${IMAGE_REF}:latest"
 
   # ── frontend-app SPA (demo relying-party) ────────────────────────────────
   build-frontend-app:
@@ -358,7 +353,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build frontend-app image
+      # Build once with load:true so Trivy scans the exact bytes we later push.
+      - name: Build frontend-app image (load locally — Trivy scans before any push)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -372,35 +368,26 @@ jobs:
             VITE_NOVA_ID_CLIENT_ID=nova-id-test-app
             VITE_OAUTH_ISSUER=https://id.cativo.dev/
           tags: |
-            ${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-frontend-app:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-app:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Trivy scan — frontend-app (fail on CRITICAL or HIGH)
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: '${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}'
           format: table
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
 
-      - name: Push frontend-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.frontend.prod
-          push: true
-          build-args: |
-            SPA=frontend-app
-            VITE_OATHKEEPER_URL=/api
-            VITE_APP_URL=https://app.cativo.dev
-            VITE_NOVA_ID_CLIENT_ID=nova-id-test-app
-            VITE_OAUTH_ISSUER=https://id.cativo.dev/
-          tags: |
-            ${{ env.IMAGE_PREFIX }}-frontend-app:${{ steps.tag.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}-frontend-app:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Push the already-built, already-scanned local image — no rebuild.
+      - name: Push scanned frontend-app image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend-app
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          docker push "${IMAGE_REF}:${VERSION}"
+          docker push "${IMAGE_REF}:latest"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -294,7 +294,7 @@ services:
   api:
     # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
     # Never built on the server — use scripts/deploy-prod.sh to deploy.
-    image: cativo23/nova-id-api:${IMAGE_TAG:-latest}
+    image: cativo23/nova-id-api:${IMAGE_TAG:?IMAGE_TAG must be set}
     command: ["node", "dist/main"]
     # No source bind-mount. No anonymous /app/node_modules.
     # api_logs provides persistent log retention across restarts.
@@ -331,7 +331,7 @@ services:
 
   demo-api:
     # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
-    image: cativo23/nova-id-demo-api:${IMAGE_TAG:-latest}
+    image: cativo23/nova-id-demo-api:${IMAGE_TAG:?IMAGE_TAG must be set}
     command: ["node", "dist/main"]
     volumes:
       - demo_api_logs:/app/logs
@@ -377,7 +377,7 @@ services:
     # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
     # VITE_* build-args are baked into the image by release.yml — see
     # .github/workflows/release.yml job build-frontend-auth.
-    image: cativo23/nova-id-frontend-auth:${IMAGE_TAG:-latest}
+    image: cativo23/nova-id-frontend-auth:${IMAGE_TAG:?IMAGE_TAG must be set}
     # nginx starts by default — no command override needed.
     # No bind-mounts in production — static files are baked into the image.
     networks:
@@ -399,7 +399,7 @@ services:
     # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
     # VITE_* build-args are baked into the image by release.yml — see
     # .github/workflows/release.yml job build-frontend-admin.
-    image: cativo23/nova-id-frontend-admin:${IMAGE_TAG:-latest}
+    image: cativo23/nova-id-frontend-admin:${IMAGE_TAG:?IMAGE_TAG must be set}
     networks:
       - apps
       - web
@@ -423,7 +423,7 @@ services:
     # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
     # VITE_* build-args are baked into the image by release.yml — see
     # .github/workflows/release.yml job build-frontend-app.
-    image: cativo23/nova-id-frontend-app:${IMAGE_TAG:-latest}
+    image: cativo23/nova-id-frontend-app:${IMAGE_TAG:?IMAGE_TAG must be set}
     networks:
       - apps
       - web

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -292,9 +292,9 @@ services:
   # and ory-internal networks.
 
   api:
-    build:
-      context: ./api
-      dockerfile: Dockerfile
+    # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
+    # Never built on the server — use scripts/deploy-prod.sh to deploy.
+    image: cativo23/nova-id-api:${IMAGE_TAG:-latest}
     command: ["node", "dist/main"]
     # No source bind-mount. No anonymous /app/node_modules.
     # api_logs provides persistent log retention across restarts.
@@ -330,9 +330,8 @@ services:
   # published ports, no ory-internal network access.
 
   demo-api:
-    build:
-      context: ./demo-api
-      dockerfile: Dockerfile
+    # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
+    image: cativo23/nova-id-demo-api:${IMAGE_TAG:-latest}
     command: ["node", "dist/main"]
     volumes:
       - demo_api_logs:/app/logs
@@ -375,20 +374,10 @@ services:
   # intentionally omitted from frontends to preserve the zero-trust boundary.
 
   frontend-auth:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend.prod
-      args:
-        SPA: frontend-auth
-        # API base — same-origin: nginx proxy_pass /api/* → oathkeeper:4455.
-        # Overrides the useAuth.ts fallback of 'http://localhost:4455'.
-        VITE_OATHKEEPER_URL: /api
-        # Open-redirect allowlist — comma-separated, parsed by safeRedirect.ts.
-        VITE_ALLOWED_REDIRECT_ORIGINS: "https://auth.cativo.dev,https://admin.cativo.dev,https://id.cativo.dev"
-        # Post-login fallback when no return_to / login_challenge is present.
-        # Defaults to 'http://app.ory.localhost' in code — must be prod URL.
-        # frontend-app is not deployed; auth.cativo.dev is the neutral fallback.
-        VITE_DEFAULT_RETURN_URL: "https://auth.cativo.dev"
+    # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
+    # VITE_* build-args are baked into the image by release.yml — see
+    # .github/workflows/release.yml job build-frontend-auth.
+    image: cativo23/nova-id-frontend-auth:${IMAGE_TAG:-latest}
     # nginx starts by default — no command override needed.
     # No bind-mounts in production — static files are baked into the image.
     networks:
@@ -407,25 +396,10 @@ services:
     restart: unless-stopped
 
   frontend-admin:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend.prod
-      args:
-        SPA: frontend-admin
-        # API base — same-origin: nginx proxy_pass /api/* → oathkeeper:4455.
-        # Overrides the useAuth.ts fallback of 'http://localhost:4455'.
-        VITE_OATHKEEPER_URL: /api
-        # Auth SPA URL — used for login redirect (Home.vue) and logout URL
-        # normalisation (useAuth.ts getAuthBaseUrl fallback chain).
-        VITE_AUTH_UI_URL: "https://auth.cativo.dev"
-        # Kratos browser (public) base for the auth SPA routes.
-        # Used by getAuthBaseUrl() and recovery link normalisation.
-        VITE_KRATOS_BROWSER_URL: "https://auth.cativo.dev/auth"
-        # Admin SPA URL — used as returnTo for verification email flows.
-        VITE_ADMIN_URL: "https://admin.cativo.dev"
-        # VITE_AUDIT_API_URL intentionally omitted: the API has no public HTTP
-        # audit ingestion endpoint (AuditService is internal). Leaving it unset
-        # triggers the no-op branch in useAuditLog.ts (if (!auditUrl) return).
+    # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
+    # VITE_* build-args are baked into the image by release.yml — see
+    # .github/workflows/release.yml job build-frontend-admin.
+    image: cativo23/nova-id-frontend-admin:${IMAGE_TAG:-latest}
     networks:
       - apps
       - web
@@ -446,26 +420,10 @@ services:
   # a sample resource server under /api-test/*. nginx proxies /api/* and /api-test/*
   # to Oathkeeper (same-origin), so no browser CORS to the gateway is needed.
   frontend-app:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend.prod
-      args:
-        SPA: frontend-app
-        # API base — same-origin: nginx proxy_pass /api/* → oathkeeper:4455.
-        VITE_OATHKEEPER_URL: /api
-        # Public origin of this app — drives the OAuth redirect_uri
-        # (`${VITE_APP_URL}/callback`, see Home.vue / useHydraOAuth.ts). MUST match
-        # the redirect_uris registered on the Hydra client.
-        VITE_APP_URL: "https://app.cativo.dev"
-        # OAuth2 client_id registered in Hydra (public client, PKCE, no secret).
-        VITE_NOVA_ID_CLIENT_ID: "nova-id-test-app"
-        # Real id_token issuer (Hydra urls.self.issuer) — used to validate the `iss`
-        # claim. NOT the proxy base (${origin}/api/hydra-public) used to reach Hydra.
-        VITE_OAUTH_ISSUER: "https://id.cativo.dev/"
-        # VITE_HYDRA_PUBLIC_URL intentionally omitted: useHydraOAuth.ts falls back to
-        # `${origin}/api/hydra-public` for non-.ory.localhost hosts, which routes via
-        # this nginx /api/* → oathkeeper hydra-public rule. Same for VITE_API_TEST_URL
-        # (defaults to `${origin}/api-test`).
+    # Image pulled by deploy-prod.sh; IMAGE_TAG exported before `docker compose up`.
+    # VITE_* build-args are baked into the image by release.yml — see
+    # .github/workflows/release.yml job build-frontend-app.
+    image: cativo23/nova-id-frontend-app:${IMAGE_TAG:-latest}
     networks:
       - apps
       - web


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered by `v*` tag push or `workflow_dispatch(ref)`
- Builds 5 Docker images in parallel: api, demo-api, frontend-auth, frontend-admin, frontend-app
- Trivy scans each after build, before push — fails on CRITICAL/HIGH CVEs
- Pushes `:vX.Y.Z` + `:latest` tags to Docker Hub (`cativo23/nova-id-*`)
- Kept separate from `ci.yml` so release builds never block development PRs
- Migrates `docker-compose.production.yml` app services from `build:` contexts to `image: cativo23/nova-id-*:${IMAGE_TAG:-latest}` — server never builds images
- Updates `ci.yml` `build-prod-images` to a no-op dry-run (compose file still parse-validated; full builds are now release.yml's job)
- Security: `workflow_dispatch` ref input flows through `env:` vars in all `run:` steps, not interpolated directly into shell

## Test plan

- [ ] PR CI passes (workflow only — no tag push yet, so release.yml does not run)
- [ ] After merge: fast-forward main to develop (prereq A in the plan), then push `git tag v0.0.1-test && git push origin v0.0.1-test`
- [ ] Confirm 5 image build jobs appear green in GitHub Actions
- [ ] Confirm 5 repos appear at hub.docker.com/u/cativo23 tagged `v0.0.1-test` and `latest`
- [ ] Confirm repos are **Public**
- [ ] Clean up test tag: `git tag -d v0.0.1-test && git push origin :refs/tags/v0.0.1-test`

The live image-push is verified manually via a tag after merge — it cannot be simulated locally (requires Docker Hub credentials in Actions secrets).

https://claude.ai/code/session_01PszuPmkLkeDUv8Ycp2rscs