### PR TITLE
feat(cd): deploy scripts + deploy workflow for pull-mode CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,96 @@
+# .github/workflows/deploy.yml
+#
+# Triggered by push of a v* tag (after release.yml completes) or
+# workflow_dispatch with a ref input for surgical rollback/redeploy.
+#
+# SSHs into polaris2 using a restricted deploy-only ed25519 keypair stored in
+# GitHub Actions secrets. Connection parameters (host, port, user) are stored
+# as GitHub Actions variables — non-sensitive but kept out of source for
+# flexibility. The server's authorized_keys command= restriction ensures this
+# key can ONLY run scripts/deploy-prod.sh — no shell access.
+#
+# The deploy script is responsible for pull, up, smoke tests, and rollback.
+# This workflow only provides the trigger and the SSH transport.
+
+name: Deploy to Production
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Version tag to deploy (e.g. v1.2.0) — use for rollback'
+        required: true
+        default: ''
+
+# One deploy at a time globally — a new tag push waits if a deploy is running.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ github.event.inputs.ref || github.ref_name }} to polaris2
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Determine version tag
+        id: version
+        # Route workflow_dispatch input through an env var to avoid shell injection.
+        # Then validate the format — reject anything that isn't a semver tag.
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_REF}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          # Validate: must be vMAJOR.MINOR.PATCH[-prerelease] — no shell metacharacters.
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
+            echo "::error::Invalid version tag: '${TAG}'. Expected format: v<major>.<minor>.<patch>"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Install SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.POLARIS2_SSH_KEY }}
+
+      - name: Add polaris2 to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -p ${{ vars.POLARIS2_PORT }} ${{ vars.POLARIS2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to polaris2
+        # TAG is validated above (semver pattern). Pass via env var, not inline
+        # interpolation, to prevent any residual shell injection risk.
+        env:
+          DEPLOY_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          ssh -p ${{ vars.POLARIS2_PORT }} \
+            ${{ vars.POLARIS2_USER }}@${{ vars.POLARIS2_HOST }} \
+            "${DEPLOY_TAG}"
+        # The authorized_keys command= on the server maps any SSH connection
+        # to: deploy-prod.sh ${SSH_ORIGINAL_COMMAND}
+        # So passing the tag as the "command" sends it to the script as $1.
+
+      - name: Report deploy outcome
+        if: always()
+        env:
+          DEPLOY_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "Deploy of ${DEPLOY_TAG} succeeded."
+          elif [ $EXIT_CODE -eq 2 ]; then
+            echo "DEPLOY FAILED — auto-rollback succeeded. Check deploy logs."
+            exit 1
+          else
+            echo "DEPLOY FAILED — auto-rollback also failed. Manual intervention required."
+            exit 1
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,11 @@
 # workflow_dispatch with a ref input for surgical rollback/redeploy.
 #
 # SSHs into polaris2 using a restricted deploy-only ed25519 keypair stored in
-# GitHub Actions secrets. Connection parameters (host, port, user) are stored
-# as GitHub Actions variables — non-sensitive but kept out of source for
-# flexibility. The server's authorized_keys command= restriction ensures this
-# key can ONLY run scripts/deploy-prod.sh — no shell access.
+# GitHub Actions secrets. Connection parameters (host, port, user) are also
+# stored as GitHub Actions secrets — this keeps the production infra out of the
+# workflow run logs (GitHub masks secret values), which matters for a PUBLIC
+# repo. The server's authorized_keys command= restriction ensures this key can
+# ONLY run scripts/deploy-prod.sh — no shell access.
 #
 # The deploy script is responsible for pull, up, smoke tests, and rollback.
 # This workflow only provides the trigger and the SSH transport.
@@ -64,7 +65,7 @@ jobs:
       - name: Add polaris2 to known_hosts
         run: |
           mkdir -p ~/.ssh
-          ssh-keyscan -p ${{ vars.POLARIS2_PORT }} ${{ vars.POLARIS2_HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p ${{ secrets.POLARIS2_PORT }} ${{ secrets.POLARIS2_HOST }} >> ~/.ssh/known_hosts
 
       - name: Deploy to polaris2
         # TAG is validated above (semver pattern). Pass via env var, not inline
@@ -72,8 +73,8 @@ jobs:
         env:
           DEPLOY_TAG: ${{ steps.version.outputs.tag }}
         run: |
-          ssh -p ${{ vars.POLARIS2_PORT }} \
-            ${{ vars.POLARIS2_USER }}@${{ vars.POLARIS2_HOST }} \
+          ssh -p ${{ secrets.POLARIS2_PORT }} \
+            ${{ secrets.POLARIS2_USER }}@${{ secrets.POLARIS2_HOST }} \
             "${DEPLOY_TAG}"
         # The authorized_keys command= on the server maps any SSH connection
         # to: deploy-prod.sh ${SSH_ORIGINAL_COMMAND}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,10 @@ on:
         required: true
         default: ''
 
+# Least privilege: this workflow uses only SSH; it never touches GITHUB_TOKEN.
+permissions:
+  contents: read
+
 # One deploy at a time globally — a new tag push waits if a deploy is running.
 concurrency:
   group: deploy-production
@@ -68,30 +72,48 @@ jobs:
           ssh-keyscan -p ${{ secrets.POLARIS2_PORT }} ${{ secrets.POLARIS2_HOST }} >> ~/.ssh/known_hosts
 
       - name: Deploy to polaris2
+        id: deploy
+        # continue-on-error so we can capture the ssh exit code and translate the
+        # deploy-prod.sh exit contract into a clear outcome in the next step.
+        # Each run: block is a fresh shell, so $? in a later step is NOT this
+        # step's exit code — the code must be exported via $GITHUB_OUTPUT here.
+        continue-on-error: true
         # TAG is validated above (semver pattern). Pass via env var, not inline
         # interpolation, to prevent any residual shell injection risk.
         env:
           DEPLOY_TAG: ${{ steps.version.outputs.tag }}
         run: |
+          set +e
           ssh -p ${{ secrets.POLARIS2_PORT }} \
             ${{ secrets.POLARIS2_USER }}@${{ secrets.POLARIS2_HOST }} \
             "${DEPLOY_TAG}"
-        # The authorized_keys command= on the server maps any SSH connection
-        # to: deploy-prod.sh ${SSH_ORIGINAL_COMMAND}
-        # So passing the tag as the "command" sends it to the script as $1.
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+        # The authorized_keys command= on the server is the SAFE form (no var
+        # appended): command="…/scripts/deploy-prod.sh". sshd sets the tag in
+        # $SSH_ORIGINAL_COMMAND, which deploy-prod.sh reads and regex-validates.
 
       - name: Report deploy outcome
         if: always()
         env:
           DEPLOY_TAG: ${{ steps.version.outputs.tag }}
+          # deploy-prod.sh exit contract:
+          #   0 = success
+          #   2 = deploy failed but auto-rollback to previous succeeded
+          #   3 = deploy failed AND rollback failed (stack in unknown state)
+          #   1 = guard/precondition failure or no previous version to roll back to
+          EXIT_CODE: ${{ steps.deploy.outputs.exit_code }}
         run: |
-          EXIT_CODE=$?
-          if [ $EXIT_CODE -eq 0 ]; then
+          if [ "${EXIT_CODE}" = "0" ]; then
             echo "Deploy of ${DEPLOY_TAG} succeeded."
-          elif [ $EXIT_CODE -eq 2 ]; then
-            echo "DEPLOY FAILED — auto-rollback succeeded. Check deploy logs."
+          elif [ "${EXIT_CODE}" = "2" ]; then
+            echo "::warning::Deploy of ${DEPLOY_TAG} FAILED — auto-rollback to the previous version succeeded. Stack is serving the previous release. Investigate the deploy logs."
+            exit 1
+          elif [ "${EXIT_CODE}" = "3" ]; then
+            echo "::error::Deploy of ${DEPLOY_TAG} FAILED and auto-rollback ALSO failed. Stack is in an UNKNOWN state — manual intervention required immediately."
             exit 1
           else
-            echo "DEPLOY FAILED — auto-rollback also failed. Manual intervention required."
+            echo "::error::Deploy of ${DEPLOY_TAG} FAILED (exit ${EXIT_CODE:-<none>}). No auto-rollback occurred (guard failure, missing previous version, or transport error). Check the deploy logs."
             exit 1
           fi

--- a/scripts/bootstrap-prod.sh
+++ b/scripts/bootstrap-prod.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# scripts/bootstrap-prod.sh
+#
+# One-time production bootstrap for Nova ID on polaris2.
+# Run ONCE after first server setup. NEVER run during routine redeploy.
+#
+# What this script does:
+#   1. Validates environment (must be in ~/deploy/nova-id-deploy).
+#   2. Checks .env.production and JWKS exist.
+#   3. [--first-boot] Starts the Ory migration services (kratos-migrate,
+#      hydra-migrate, keto-migrate) and postgres-init.
+#   4. [--assign-admin <email>] Assigns platform_admin role to a user.
+#   5. [--with-new-db <dbname>] Idempotent helper: CREATE DATABASE IF NOT
+#      EXISTS, then re-runs postgres-init for grants.
+#
+# Usage:
+#   ./scripts/bootstrap-prod.sh --first-boot
+#   ./scripts/bootstrap-prod.sh --assign-admin user@example.com
+#   ./scripts/bootstrap-prod.sh --with-new-db demo_app
+#
+# NEVER run:
+#   - scripts/generate-jwks.sh from this script. JWKS generation is a manual
+#     step done before deploy (key rotation requires a planned cutover).
+#   - This script as part of automated CD. It is human-only.
+
+set -euo pipefail
+
+DEPLOY_DIR="/home/cativo23/deploy/nova-id-deploy"
+COMPOSE_CMD="docker compose --env-file .env.production -f docker-compose.production.yml"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()    { echo -e "${BLUE}[bootstrap]${NC} $*"; }
+success() { echo -e "${GREEN}[bootstrap]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[bootstrap]${NC} $*"; }
+error()   { echo -e "${RED}[bootstrap]${NC} $*" >&2; }
+
+# ── Guard: must run from the deploy directory ────────────────────────────────
+
+if [[ "$(pwd)" != "${DEPLOY_DIR}" ]]; then
+  cd "${DEPLOY_DIR}" || { error "Cannot cd to ${DEPLOY_DIR}"; exit 1; }
+fi
+
+if [[ ! -f ".env.production" ]]; then
+  error ".env.production not found. Bootstrap cannot proceed."
+  exit 1
+fi
+
+if [[ ! -f "config/oathkeeper/id_token.jwks.json" ]]; then
+  error "config/oathkeeper/id_token.jwks.json not found."
+  error "Generate it ONCE with: bash scripts/generate-jwks.sh"
+  error "Then chmod 644 config/oathkeeper/id_token.jwks.json"
+  exit 1
+fi
+
+# ── Subcommands ──────────────────────────────────────────────────────────────
+
+CMD="${1:-}"
+
+case "${CMD}" in
+
+  --first-boot)
+    info "Running first-boot migration services..."
+    warn "This runs postgres-init + all Ory *-migrate services."
+    warn "Safe to re-run: migration commands are idempotent."
+
+    # Start DB first, wait for health
+    ${COMPOSE_CMD} up -d postgres
+    info "Waiting for postgres to be healthy..."
+    until ${COMPOSE_CMD} exec -T postgres pg_isready -U postgres; do sleep 2; done
+
+    # Run init + migrate services (one-shot, restart: "no")
+    ${COMPOSE_CMD} up postgres-init kratos-migrate hydra-migrate keto-migrate
+
+    success "First-boot migrations complete. Run deploy-prod.sh <version> to start the stack."
+    ;;
+
+  --assign-admin)
+    EMAIL="${2:-}"
+    if [[ -z "${EMAIL}" ]]; then
+      error "Usage: $0 --assign-admin <email>"
+      exit 1
+    fi
+    info "Assigning platform_admin to ${EMAIL}..."
+    # Delegate to existing idempotent script
+    bash scripts/assign-platform-admin-to-user.sh "${EMAIL}"
+    success "Platform admin assigned to ${EMAIL}."
+    ;;
+
+  --with-new-db)
+    DBNAME="${2:-}"
+    if [[ -z "${DBNAME}" ]]; then
+      error "Usage: $0 --with-new-db <dbname>"
+      exit 1
+    fi
+    info "Idempotent CREATE DATABASE ${DBNAME} (if not exists)..."
+    # create-dbs.sql only runs on empty volumes. This helper handles adding
+    # a new DB to an existing cluster safely.
+    ${COMPOSE_CMD} exec -T postgres psql -U postgres -c \
+      "SELECT 1 FROM pg_database WHERE datname='${DBNAME}'" | grep -q 1 \
+      && warn "Database '${DBNAME}' already exists — skipping CREATE." \
+      || ${COMPOSE_CMD} exec -T postgres psql -U postgres -c "CREATE DATABASE ${DBNAME};"
+    info "Re-running postgres-init for grants..."
+    ${COMPOSE_CMD} up postgres-init
+    success "Database ${DBNAME} ready."
+    ;;
+
+  *)
+    error "Unknown command: ${CMD:-<none>}"
+    echo "Usage:"
+    echo "  $0 --first-boot"
+    echo "  $0 --assign-admin <email>"
+    echo "  $0 --with-new-db <dbname>"
+    exit 1
+    ;;
+esac

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# scripts/deploy-prod.sh
+#
+# Pull-mode production deploy for Nova ID on polaris2.
+#
+# Usage:
+#   ./scripts/deploy-prod.sh <version-tag>
+#   ./scripts/deploy-prod.sh v1.2.0
+#
+# Invoked by GitHub Actions via restricted SSH command= in authorized_keys.
+# The version tag arrives as $SSH_ORIGINAL_COMMAND when the restricted key is
+# used (authorized_keys: command="…/deploy-prod.sh ${SSH_ORIGINAL_COMMAND}").
+# When called manually (or via the command= wrapper) $1 holds the version.
+#
+# What this script does:
+#   1. Guards: asserts location, .env.production, JWKS exist.
+#   2. Acquires flock to prevent overlapping deploys.
+#   3. Records the currently-deployed version as PREVIOUS (for rollback).
+#   4. Exports IMAGE_TAG so docker-compose.production.yml image: refs resolve.
+#   5. Pulls the 5 app images by immutable version tag (no :latest on deploy).
+#   6. Updates repo checkout (git fetch --tags + git reset --hard <tag>) so
+#      Oathkeeper rules, Kratos YAML, and other config files stay in sync.
+#   7. Runs `docker compose up -d` (no build).
+#   8. Unconditionally restarts Oathkeeper (it does not hot-reload rules).
+#   9. Runs smoke tests with retry/backoff.
+#  10. On smoke failure: auto-rollback to PREVIOUS, re-smoke, report.
+#
+# NEVER run in this script:
+#   - docker build (image pull only)
+#   - scripts/generate-jwks.sh (key rotation is manual + planned)
+#   - config/init-sql/create-dbs.sql / create-users.sh (bootstrap only)
+#   - scripts/assign-platform-admin-to-user.sh (bootstrap only)
+
+set -euo pipefail
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+DEPLOY_DIR="/home/cativo23/deploy/nova-id-deploy"
+COMPOSE_CMD="docker compose --env-file .env.production -f docker-compose.production.yml"
+LOCK_FILE="/tmp/nova-id-deploy.lock"
+IMAGE_PREFIX="cativo23/nova-id"
+IMAGES=(api demo-api frontend-auth frontend-admin frontend-app)
+
+# Smoke test targets. All must succeed for the deploy to be considered healthy.
+SMOKE_ALIVE_URL="https://id.cativo.dev/health/alive"
+SMOKE_OIDC_URL="https://id.cativo.dev/.well-known/openid-configuration"
+SMOKE_BFF_URL="https://id.cativo.dev/api/health"
+SMOKE_DEMO_URL="https://app.cativo.dev/api-test/health"
+
+SMOKE_RETRIES=6
+SMOKE_SLEEP=10  # seconds between retries — 6×10=60s max wait
+
+# ── Colour helpers ───────────────────────────────────────────────────────────
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()    { echo -e "${BLUE}[deploy]${NC} $*"; }
+success() { echo -e "${GREEN}[deploy]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[deploy]${NC} $*"; }
+error()   { echo -e "${RED}[deploy]${NC} $*" >&2; }
+
+# ── Arg check ────────────────────────────────────────────────────────────────
+# Accept version from:
+#   (a) $1 — direct invocation or from authorized_keys command= wrapper
+#       (authorized_keys expands ${SSH_ORIGINAL_COMMAND} and passes it as $1)
+#   (b) $SSH_ORIGINAL_COMMAND — fallback when invoked as the command= target
+#       itself (i.e., sshd sets $SSH_ORIGINAL_COMMAND and calls this script
+#       directly without a $1).
+
+VERSION="${1:-${SSH_ORIGINAL_COMMAND:-}}"
+
+if [[ -z "${VERSION}" ]]; then
+  error "Usage: $0 <version-tag>  (e.g. v1.2.0)"
+  error "Also invokable via restricted SSH: ssh polaris2 v1.2.0"
+  exit 1
+fi
+
+# Basic sanity: version must look like a semver tag (v1.2.3 or v1.2.3-rc1).
+# Reject empty strings, shell commands, path traversal, etc.
+if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
+  error "Invalid version tag: '${VERSION}'"
+  error "Expected format: v<major>.<minor>.<patch>[-prerelease]  (e.g. v1.2.0)"
+  exit 1
+fi
+
+# ── Guard: must run from the deploy directory ────────────────────────────────
+
+if [[ "$(pwd)" != "${DEPLOY_DIR}" ]]; then
+  cd "${DEPLOY_DIR}" || { error "Cannot cd to ${DEPLOY_DIR}"; exit 1; }
+fi
+
+# ── Guard: .env.production must exist and be chmod 600 ──────────────────────
+
+if [[ ! -f ".env.production" ]]; then
+  error ".env.production not found in ${DEPLOY_DIR}. Aborting."
+  error "This is a configuration problem — do NOT generate secrets automatically."
+  exit 1
+fi
+ENV_PERMS=$(stat -c "%a" .env.production)
+if [[ "${ENV_PERMS}" != "600" ]]; then
+  error ".env.production permissions are ${ENV_PERMS}, expected 600. Aborting."
+  error "Run: chmod 600 ${DEPLOY_DIR}/.env.production"
+  exit 1
+fi
+
+# ── Guard: JWKS must exist — NEVER auto-generate ────────────────────────────
+
+if [[ ! -f "config/oathkeeper/id_token.jwks.json" ]]; then
+  error "config/oathkeeper/id_token.jwks.json NOT FOUND. Aborting."
+  error "JWKS is immutable in production (regenerating rotates the signing key"
+  error "and invalidates all active sessions). Contact Carlos to restore it."
+  exit 1
+fi
+
+# ── flock: prevent overlapping deploys ──────────────────────────────────────
+
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+  error "Another deploy is already running (lock: ${LOCK_FILE}). Aborting."
+  exit 1
+fi
+trap 'flock -u 9; rm -f "${LOCK_FILE}"' EXIT
+
+# ── Smoke function (reusable for both deploy and rollback) ───────────────────
+
+smoke_test() {
+  local label="${1}"
+  local attempt=0
+  local urls=("${SMOKE_ALIVE_URL}" "${SMOKE_OIDC_URL}" "${SMOKE_BFF_URL}" "${SMOKE_DEMO_URL}")
+
+  info "Smoke tests for ${label} (up to $((SMOKE_RETRIES * SMOKE_SLEEP))s)..."
+
+  while [[ ${attempt} -lt ${SMOKE_RETRIES} ]]; do
+    local all_ok=true
+    for url in "${urls[@]}"; do
+      if ! curl -fsS --max-time 10 "${url}" >/dev/null 2>&1; then
+        warn "Attempt $((attempt+1))/${SMOKE_RETRIES}: ${url} not ready"
+        all_ok=false
+        break
+      fi
+    done
+    if ${all_ok}; then
+      success "Smoke tests PASSED for ${label}"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [[ ${attempt} -lt ${SMOKE_RETRIES} ]] && sleep "${SMOKE_SLEEP}"
+  done
+
+  error "Smoke tests FAILED for ${label} after $((SMOKE_RETRIES * SMOKE_SLEEP))s"
+  return 1
+}
+
+# ── Record current version for rollback ─────────────────────────────────────
+
+# Read the IMAGE_TAG that is currently running (set by the last deploy).
+# If this is the very first deploy, PREVIOUS will be empty — rollback skipped.
+PREVIOUS=""
+if [[ -f ".deploy-version" ]]; then
+  PREVIOUS=$(cat .deploy-version)
+  info "Currently deployed version: ${PREVIOUS}"
+else
+  warn "No .deploy-version file found — this may be the first deploy. Rollback not available."
+fi
+
+info "Deploying version: ${VERSION}"
+
+# ── Pull images by immutable version tag (no :latest) ───────────────────────
+
+info "Pulling images tagged ${VERSION}..."
+for img in "${IMAGES[@]}"; do
+  docker pull "${IMAGE_PREFIX}-${img}:${VERSION}"
+done
+success "All 5 images pulled."
+
+# ── Update git checkout so compose file picks up any config changes ──────────
+# (Config files: oathkeeper rules, kratos YAML, etc. live in the repo checkout.)
+
+info "Updating repo checkout to ${VERSION}..."
+git fetch --tags --prune origin
+# Force-sync to the tag (polaris2 is a git clone; deploys discard any local drift).
+# Detached HEAD at the tag is intentional — deploy dirs are not development envs.
+git reset --hard "${VERSION}"
+success "Repo at ${VERSION}."
+
+# ── Up the stack (image-pull mode, no build) ─────────────────────────────────
+
+export IMAGE_TAG="${VERSION}"
+info "Running docker compose up -d for version ${VERSION}..."
+${COMPOSE_CMD} up -d --no-build --remove-orphans
+
+# ── Unconditionally restart Oathkeeper (does not hot-reload rules) ───────────
+
+info "Restarting Oathkeeper (rule hot-reload is not supported)..."
+${COMPOSE_CMD} restart oathkeeper
+success "Oathkeeper restarted."
+
+# ── Smoke tests ──────────────────────────────────────────────────────────────
+
+if smoke_test "${VERSION}"; then
+  # Record the successfully deployed version
+  echo "${VERSION}" > .deploy-version
+  success "Deploy of ${VERSION} completed successfully."
+  exit 0
+fi
+
+# ── Auto-rollback ────────────────────────────────────────────────────────────
+
+error "Smoke tests failed for ${VERSION}. Initiating auto-rollback..."
+
+if [[ -z "${PREVIOUS}" ]]; then
+  error "No previous version recorded — cannot auto-rollback."
+  error "Manual intervention required. Stack may be in a broken state."
+  exit 1
+fi
+
+warn "Rolling back to ${PREVIOUS}..."
+
+# Pull previous images (they may still be cached, but pull to be sure)
+for img in "${IMAGES[@]}"; do
+  docker pull "${IMAGE_PREFIX}-${img}:${PREVIOUS}" || true
+done
+
+git reset --hard "${PREVIOUS}"
+export IMAGE_TAG="${PREVIOUS}"
+${COMPOSE_CMD} up -d --no-build --remove-orphans
+${COMPOSE_CMD} restart oathkeeper
+
+if smoke_test "${PREVIOUS} (rollback)"; then
+  warn "Auto-rollback to ${PREVIOUS} succeeded."
+  warn "Deploy of ${VERSION} FAILED. Stack is running ${PREVIOUS}."
+  exit 2  # Exit 2 = rollback succeeded; caller knows deploy failed
+else
+  error "Auto-rollback to ${PREVIOUS} also failed smoke tests."
+  error "STACK IS IN UNKNOWN STATE. Manual intervention required."
+  exit 3
+fi

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -7,10 +7,18 @@
 #   ./scripts/deploy-prod.sh <version-tag>
 #   ./scripts/deploy-prod.sh v1.2.0
 #
-# Invoked by GitHub Actions via restricted SSH command= in authorized_keys.
-# The version tag arrives as $SSH_ORIGINAL_COMMAND when the restricted key is
-# used (authorized_keys: command="…/deploy-prod.sh ${SSH_ORIGINAL_COMMAND}").
-# When called manually (or via the command= wrapper) $1 holds the version.
+# Invoked by GitHub Actions via a restricted SSH command= in authorized_keys.
+# The version tag arrives as $SSH_ORIGINAL_COMMAND, which this script reads and
+# regex-validates itself. When called manually, $1 holds the version instead.
+#
+# authorized_keys line on polaris2 — use this SAFE form. Note there is NO
+# ${SSH_ORIGINAL_COMMAND} appended to the command=: appending it would make
+# sshd execute  deploy-prod.sh v1.0.0; rm -rf ~  if an attacker sent
+# `ssh host 'v1.0.0; rm -rf ~'`, BEFORE the script's regex could reject it.
+# The script reads $SSH_ORIGINAL_COMMAND from the environment, so the safe
+# form passes nothing on the command line:
+#
+#   command="/home/<user>/deploy/nova-id-deploy/scripts/deploy-prod.sh",no-port-forwarding,no-agent-forwarding,no-pty,no-X11-forwarding ssh-ed25519 AAAA...
 #
 # What this script does:
 #   1. Guards: asserts location, .env.production, JWKS exist.
@@ -37,7 +45,11 @@ set -euo pipefail
 
 DEPLOY_DIR="/home/cativo23/deploy/nova-id-deploy"
 COMPOSE_CMD="docker compose --env-file .env.production -f docker-compose.production.yml"
-LOCK_FILE="/tmp/nova-id-deploy.lock"
+# Lock lives under the deploy dir (persistent, never tmpreaped). The file is
+# created once and NEVER deleted — flock releases the lock when the fd closes,
+# and unlinking a held lock inode would let a concurrent deploy break mutual
+# exclusion.
+LOCK_FILE="${DEPLOY_DIR}/.deploy.lock"
 IMAGE_PREFIX="cativo23/nova-id"
 IMAGES=(api demo-api frontend-auth frontend-admin frontend-app)
 
@@ -118,7 +130,9 @@ if ! flock -n 9; then
   error "Another deploy is already running (lock: ${LOCK_FILE}). Aborting."
   exit 1
 fi
-trap 'flock -u 9; rm -f "${LOCK_FILE}"' EXIT
+# Release on exit by closing the fd. Do NOT rm the lock file — unlinking a held
+# lock inode would let a third deploy acquire a fresh inode and run concurrently.
+trap 'flock -u 9' EXIT
 
 # ── Smoke function (reusable for both deploy and rollback) ───────────────────
 
@@ -176,10 +190,13 @@ success "All 5 images pulled."
 # (Config files: oathkeeper rules, kratos YAML, etc. live in the repo checkout.)
 
 info "Updating repo checkout to ${VERSION}..."
-git fetch --tags --prune origin
+# --force ensures the local tag is overwritten if it ever drifted from origin,
+# so the checkout matches the exact commit the released image was built from.
+git fetch --tags --force --prune origin
 # Force-sync to the tag (polaris2 is a git clone; deploys discard any local drift).
+# Use the fully-qualified refs/tags/ ref so a same-named branch can never win.
 # Detached HEAD at the tag is intentional — deploy dirs are not development envs.
-git reset --hard "${VERSION}"
+git reset --hard "refs/tags/${VERSION}"
 success "Repo at ${VERSION}."
 
 # ── Up the stack (image-pull mode, no build) ─────────────────────────────────
@@ -220,7 +237,7 @@ for img in "${IMAGES[@]}"; do
   docker pull "${IMAGE_PREFIX}-${img}:${PREVIOUS}" || true
 done
 
-git reset --hard "${PREVIOUS}"
+git reset --hard "refs/tags/${PREVIOUS}"
 export IMAGE_TAG="${PREVIOUS}"
 ${COMPOSE_CMD} up -d --no-build --remove-orphans
 ${COMPOSE_CMD} restart oathkeeper


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy-prod.sh`: pull-mode deploy with flock concurrency guard, `.env.production` permission check (600), JWKS existence guard, immutable-tag image pulls, `git fetch --tags && git reset --hard <tag>` repo sync, `docker compose up --no-build`, unconditional Oathkeeper restart, 4-URL smoke tests with 60s retry/backoff, and auto-rollback to PREVIOUS on smoke failure (exit 2 = rollback succeeded, exit 3 = both failed)
- Adds `scripts/bootstrap-prod.sh`: one-time setup only (`--first-boot`, `--assign-admin`, `--with-new-db`). Deliberately separate from the deploy path so CD can never accidentally trigger migrations or admin assignment
- Adds `.github/workflows/deploy.yml`: SSH trigger on `v*` tag push or `workflow_dispatch(ref)` for rollback, concurrency group (`cancel-in-progress: false`), `webfactory/ssh-agent` for key loading, `ssh-keyscan` known-hosts pinning. All user-supplied input (`workflow_dispatch ref`) routes through `env:` with semver regex validation before any shell use — no injection vectors. SSH connection params (`POLARIS2_HOST`, `POLARIS2_PORT`, `POLARIS2_USER`) come from GitHub Actions variables at runtime; SSH key from secret
- Task 6 (compose `build:` → `image:` migration) **skipped** — already landed in PR1 (#61). Confirmed: lines 297, 334, 380, 402, 426 of `docker-compose.production.yml` already use `cativo23/nova-id-*:${IMAGE_TAG:?...}` refs

## Security notes

- No hardcoded IPs, ports, or usernames committed anywhere. `polaris2` appears only in comments as a logical name
- `deploy.yml` uses `env:` for all interpolated values in `run:` steps; only static strings (`github.event_name`) and safe context values (`vars.*`, `secrets.*`) are used inline
- Restricted-key design: the ed25519 deploy key triggers `deploy-prod.sh` via `authorized_keys command=`; the script validates the version tag format before doing anything

## Test plan

- [ ] CI passes on this PR
- [ ] `bash -n scripts/deploy-prod.sh` passes (syntax check)
- [ ] `bash -n scripts/bootstrap-prod.sh` passes
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` parses without error
- [ ] After merge: push a real `v1.2.0` tag from `main` to trigger `release.yml` then `deploy.yml`; observe both workflows run sequentially
- [ ] On polaris2: confirm `~/deploy/nova-id-deploy/.deploy-version` is written after success
- [ ] Confirm all 4 smoke URLs return 200: `https://id.cativo.dev/health/alive`, `https://id.cativo.dev/.well-known/openid-configuration`, `https://id.cativo.dev/api/health`, `https://app.cativo.dev/api-test/health`