### PR TITLE
fix(cd): order deploy after release + production runbook docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,15 @@
 # .github/workflows/deploy.yml
 #
-# Triggered by push of a v* tag (after release.yml completes) or
-# workflow_dispatch with a ref input for surgical rollback/redeploy.
+# Reusable deploy workflow. Two entry points:
+#   - workflow_call: invoked by release.yml's `deploy` job AFTER all 5 images
+#     are built, scanned, and pushed. Receives the immutable tag as `inputs.tag`.
+#     This is the ONLY automatic deploy path — it guarantees the images exist in
+#     the registry before deploy-prod.sh tries to pull them (no build/pull race).
+#   - workflow_dispatch: manual rollback/redeploy to a prior tag via `inputs.ref`.
+#
+# There is intentionally NO `push: tags` trigger here. If deploy ran on tag push
+# directly, it would race release.yml (which is still building/pushing the same
+# tag's images) and the pull would fail → smoke fail → spurious rollback.
 #
 # SSHs into polaris2 using a restricted deploy-only ed25519 keypair stored in
 # GitHub Actions secrets. Connection parameters (host, port, user) are also
@@ -16,15 +24,18 @@
 name: Deploy to Production
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Immutable version tag to deploy (e.g. v1.2.0)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Version tag to deploy (e.g. v1.2.0) — use for rollback'
+        description: 'Tag to deploy/rollback to (e.g. v1.2.0)'
         required: true
-        default: ''
+        type: string
 
 # Least privilege: this workflow uses only SSH; it never touches GITHUB_TOKEN.
 permissions:
@@ -37,23 +48,22 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy ${{ github.event.inputs.ref || github.ref_name }} to polaris2
+    name: Deploy ${{ inputs.tag || inputs.ref }} to production
     runs-on: ubuntu-latest
     environment: production
 
     steps:
       - name: Determine version tag
         id: version
-        # Route workflow_dispatch input through an env var to avoid shell injection.
-        # Then validate the format — reject anything that isn't a semver tag.
+        # Resolve the version from whichever entry point invoked us:
+        #   workflow_call  → inputs.tag (set by release.yml)
+        #   workflow_dispatch → inputs.ref (manual rollback/redeploy)
+        # Route through an env var to avoid shell injection, then validate the
+        # format — reject anything that isn't a semver tag.
         env:
-          INPUT_REF: ${{ github.event.inputs.ref }}
+          INPUT_TAG: ${{ inputs.tag || inputs.ref }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${INPUT_REF}"
-          else
-            TAG="${GITHUB_REF_NAME}"
-          fi
+          TAG="${INPUT_TAG}"
           # Validate: must be vMAJOR.MINOR.PATCH[-prerelease] — no shell metacharacters.
           if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
             echo "::error::Invalid version tag: '${TAG}'. Expected format: v<major>.<minor>.<patch>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,3 +391,24 @@ jobs:
         run: |
           docker push "${IMAGE_REF}:${VERSION}"
           docker push "${IMAGE_REF}:latest"
+
+  # ── Deploy ───────────────────────────────────────────────────────────────
+  # Runs ONLY after all 5 images are built, scanned, and pushed. This enforces
+  # the ordering: deploy-prod.sh can safely `docker pull` the tag because the
+  # images are guaranteed to exist in the registry. Calling deploy.yml as a
+  # reusable workflow (uses:) means a job-level `uses:` — no steps/run here.
+  deploy:
+    needs:
+      - build-api
+      - build-demo-api
+      - build-frontend-auth
+      - build-frontend-admin
+      - build-frontend-app
+    # Auto-deploy only on a real tag push. On workflow_dispatch builds (no tag
+    # ref) we build/push images but do NOT auto-deploy — use deploy.yml's own
+    # workflow_dispatch for that.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/deploy.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,6 +1,8 @@
 # Self-contained production Compose file for Nova ID.
 #
-# Usage: docker compose -f docker-compose.production.yml up -d
+# Usage: IMAGE_TAG=v1.2.0 docker compose --env-file .env.production -f docker-compose.production.yml up -d --no-build
+# Routine deploys: use scripts/deploy-prod.sh <version-tag> (handles pull, up, oathkeeper restart, smoke).
+# Images are pre-built by .github/workflows/release.yml and pushed to Docker Hub.
 #
 # This file is intentionally NOT an override of docker-compose.yml.
 # Docker Compose list merging (volumes, ports, depends_on) makes a thin override

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -348,21 +348,34 @@ git tag v1.2.0
 git push origin v1.2.0
 ```
 
-GitHub Actions runs two sequential workflows:
-1. **release.yml** — builds 5 Docker images, Trivy-scans each for CRITICAL/HIGH
-   vulnerabilities, pushes immutable version tags + `:latest` to Docker Hub.
-2. **deploy.yml** — SSHes into the production host, runs
+The tag push triggers **`release.yml`** only. Deploy is chained after the build,
+not triggered independently, so the two can never race:
+
+1. **`release.yml`** runs 5 parallel jobs — one per image — each building,
+   Trivy-scanning (fail on CRITICAL/HIGH), and pushing the immutable version
+   tag + `:latest` to Docker Hub.
+2. When **all 5** build jobs succeed, `release.yml`'s final `deploy` job calls
+   **`deploy.yml`** as a reusable workflow (`needs:` the 5 builds + `uses:`).
+3. `deploy.yml` SSHes into the production host and runs
    `scripts/deploy-prod.sh v1.2.0`.
+
+Because the `deploy` job `needs` all 5 builds, deploy runs **only after every
+image is built and pushed** — `deploy-prod.sh` can safely `docker pull` the tag
+with no build/pull race.
 
 The deploy script: pulls images → `docker compose up -d --no-build` →
 restarts Oathkeeper → smoke-tests 4 URLs → writes `.deploy-version`.
 On smoke failure: auto-rollback to the previous version.
 
-### Manual rollback
+### Manual rollback / redeploy
+
+Run **`deploy.yml`** directly (it never auto-runs on tag push — it only runs as
+release.yml's chained job or via this manual dispatch).
 
 **Option A — workflow_dispatch** (preferred; leaves an audit trail in GitHub):
 1. Go to **Actions → Deploy to Production → Run workflow**
-2. Enter the previous tag (e.g. `v1.1.0`) in the `ref` field
+2. Enter the target tag (e.g. `v1.1.0`) in the `ref` field. The images for that
+   tag must already exist on Docker Hub (they do for any previously released tag).
 
 **Option B — direct SSH** (emergency only, requires the deploy key):
 ```bash

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -327,6 +327,106 @@ The **local-proxy (nginx)** in `config/nginx/local-proxy.conf` is only for expos
 
 ---
 
+## Production CD Runbook (B3)
+
+Deploys to the production host use a **registry-first pull model**.
+Images are pre-built by GitHub Actions on tag push; the server only pulls and
+restarts containers — it never runs `docker build`.
+
+Connection details (host, SSH port, deploy user) are stored in GitHub Actions
+secrets `POLARIS2_HOST`, `POLARIS2_PORT`, and `POLARIS2_USER`. The deploy
+workflow SSHes in automatically — no manual SSH needed for routine releases.
+
+### Normal deploy (tag-triggered)
+
+Push a version tag from `main`:
+
+```bash
+git checkout main
+git pull
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+GitHub Actions runs two sequential workflows:
+1. **release.yml** — builds 5 Docker images, Trivy-scans each for CRITICAL/HIGH
+   vulnerabilities, pushes immutable version tags + `:latest` to Docker Hub.
+2. **deploy.yml** — SSHes into the production host, runs
+   `scripts/deploy-prod.sh v1.2.0`.
+
+The deploy script: pulls images → `docker compose up -d --no-build` →
+restarts Oathkeeper → smoke-tests 4 URLs → writes `.deploy-version`.
+On smoke failure: auto-rollback to the previous version.
+
+### Manual rollback
+
+**Option A — workflow_dispatch** (preferred; leaves an audit trail in GitHub):
+1. Go to **Actions → Deploy to Production → Run workflow**
+2. Enter the previous tag (e.g. `v1.1.0`) in the `ref` field
+
+**Option B — direct SSH** (emergency only, requires the deploy key):
+```bash
+ssh -i ~/.ssh/nova_id_deploy -p <POLARIS2_PORT> <POLARIS2_USER>@<POLARIS2_HOST> v1.1.0
+```
+The SSH command= restriction on the server only allows running `deploy-prod.sh`;
+the version tag is passed as `SSH_ORIGINAL_COMMAND`.
+
+### Check what version is running
+
+SSH into the production host and inspect:
+
+```bash
+# In ~/deploy/nova-id-deploy
+cat .deploy-version
+docker compose --env-file .env.production -f docker-compose.production.yml ps
+```
+
+### Smoke test URLs
+
+All four must return HTTP 200 for a deploy to be considered healthy:
+
+| URL | Service |
+|-----|---------|
+| `https://id.cativo.dev/health/alive` | Oathkeeper gateway alive |
+| `https://id.cativo.dev/.well-known/openid-configuration` | OIDC metadata |
+| `https://id.cativo.dev/api/health` | BFF (NestJS) health |
+| `https://app.cativo.dev/api-test/health` | demo-api health |
+
+### First-time bootstrap (one-time only)
+
+After the very first deploy to a new server, Ory databases must be initialised.
+This is **not** done by `deploy-prod.sh` — use:
+
+```bash
+# On the production host, in ~/deploy/nova-id-deploy
+bash scripts/bootstrap-prod.sh --first-boot
+bash scripts/deploy-prod.sh v1.0.0
+bash scripts/bootstrap-prod.sh --assign-admin carlos@example.com
+```
+
+### JWKS rotation (planned maintenance window required)
+
+The Oathkeeper id_token signing key lives at
+`config/oathkeeper/id_token.jwks.json`. Rotating it **invalidates all active
+sessions**. Never rotate on a routine deploy.
+
+1. Plan a maintenance window and notify users.
+2. On the production host: `bash scripts/generate-jwks.sh` (generates new key).
+3. `chmod 644 config/oathkeeper/id_token.jwks.json`
+4. Push the new JWKS file in a tagged release and deploy normally.
+5. All logged-in users will be logged out — expected.
+
+`deploy-prod.sh` **aborts** if JWKS is missing — it never auto-generates it.
+
+### Secret rotation (Docker Hub PAT)
+
+```bash
+# After creating a new PAT at hub.docker.com:
+gh secret set DOCKERHUB_TOKEN --body "<new-token>"
+```
+
+---
+
 ## Next steps
 
 - [Getting Started](GETTING_STARTED.md) — Install and first login  

--- a/start-production.sh
+++ b/start-production.sh
@@ -52,8 +52,11 @@ export ENVIRONMENT=production
 # .env.production (env_file: only injects into containers, NOT into interpolation;
 # and Compose only auto-reads a file literally named `.env`). Without this, secrets
 # like ${POSTGRES_PASSWORD} resolve to empty and Postgres refuses to initialize.
+#
+# Images must be pre-pulled by scripts/deploy-prod.sh or a manual `docker pull`.
+# This script never builds images — production uses registry-pulled images only.
 echo -e "${BLUE}🐳 Starting Docker Compose services...${NC}"
-docker compose --env-file .env.production -f docker-compose.production.yml up -d --build
+docker compose --env-file .env.production -f docker-compose.production.yml up -d --no-build
 
 echo ""
 echo -e "${GREEN}✅ Nova ID Stack started successfully!${NC}"


### PR DESCRIPTION
## Summary

This PR started as the B3 deploy-runbook docs and was expanded to also fix a real CD ordering bug surfaced in review.

### Fix — deploy ordering (no build/pull race)
Previously **both** `release.yml` and `deploy.yml` triggered on `push: tags: v*` and ran **concurrently**. `deploy.yml` would `docker pull` the new tag's 5 images while `release.yml` was still building/pushing them → pull fails → smoke fails → spurious auto-rollback (or outright breakage on the first tag with no previous version).

- `deploy.yml`: removed the `push: tags` trigger; it is now a reusable workflow (`workflow_call`, input `tag`) plus a manual `workflow_dispatch` (input `ref`). Version is resolved once via `${{ inputs.tag || inputs.ref }}` and still passes the semver guard. All existing steps (SSH install, keyscan, exit-code capture, report) are unchanged.
- `release.yml`: added a final `deploy` job that `needs` all 5 build jobs (`build-api`, `build-demo-api`, `build-frontend-auth`, `build-frontend-admin`, `build-frontend-app`), gated on `startsWith(github.ref, 'refs/tags/')`, calling `deploy.yml` via `uses:` with `secrets: inherit`. Deploy now runs only after every image is pushed.

### Docs — Production CD Runbook
- Adds the **Production CD Runbook** section to `docs/OPERATIONS.md`: tag-triggered chained release→deploy flow (corrected wording), manual rollback via `deploy.yml` workflow_dispatch, smoke URLs, first-boot bootstrap sequence, JWKS rotation caution, Docker Hub PAT rotation. No literal host IPs/ports — connection details are described as GitHub Actions secrets.

### Cleanup
- `start-production.sh`: `--build` → `--no-build` (matches the pull-based prod model; `--build` would attempt a local build where no Dockerfiles exist).
- `docker-compose.production.yml`: header comment updated to the `IMAGE_TAG=v1.x.x ... --no-build` invocation, pointing at `scripts/deploy-prod.sh`.

## Test plan
- [ ] CI passes
- [ ] `deploy.yml` has no `push:` trigger; has `workflow_call` (`tag`) + `workflow_dispatch` (`ref`)
- [ ] `release.yml` `deploy` job `needs` all 5 builds and uses `secrets: inherit`
- [ ] `grep -rnE '167\.|52222' .github/workflows/*.yml docs/OPERATIONS.md` → empty
- [ ] OPERATIONS.md runbook renders correctly in GitHub