### PR TITLE
fix(kratos): reduce session lifespan to 24h rolling (was 30d)

### DIFF
--- a/config/kratos/kratos.local.yml
+++ b/config/kratos/kratos.local.yml
@@ -165,7 +165,14 @@ cookies:
   # In --dev mode, Kratos should handle Secure flag automatically
 
 session:
-  lifespan: 720h
+  lifespan: 24h
+  # earliest_possible_extend: when there is less than this duration left on the
+  # session, a /sessions/whoami call will extend it to a full 24h from now —
+  # giving rolling-session behaviour without re-login for active users.
+  # Setting to 1h means the session slides forward only in the last hour before
+  # it would expire, keeping DB write frequency low.
+  # Ref: Ory Kratos config schema (session.earliest_possible_extend), v0.13+.
+  earliest_possible_extend: 1h
   cookie:
     domain: ory.localhost
     path: /

--- a/config/kratos/kratos.production.yml
+++ b/config/kratos/kratos.production.yml
@@ -153,7 +153,14 @@ cookies:
   secure: "true"  # Ory expects string not boolean for cookies.secure
 
 session:
-  lifespan: 720h
+  lifespan: 24h
+  # earliest_possible_extend: when there is less than this duration left on the
+  # session, a /sessions/whoami call will extend it to a full 24h from now —
+  # giving rolling-session behaviour without re-login for active users.
+  # Setting to 1h means the session slides forward only in the last hour before
+  # it would expire, keeping DB write frequency low.
+  # Ref: Ory Kratos config schema (session.earliest_possible_extend), v0.13+.
+  earliest_possible_extend: 1h
   whoami:
     required_aal: highest_available
 


### PR DESCRIPTION
## What changed

- `session.lifespan`: `720h` → `24h` in both `kratos.production.yml` and `kratos.local.yml`
- `session.earliest_possible_extend: 1h` added to both files (new key)

Both files are kept in sync as required.

## Why

A 30-day IdP session is an unnecessarily wide blast radius: a stolen session cookie (e.g. via XSS on a connected SPA, physical device access, or network interception) gives an attacker a full month of access with no revocation window. 24h is the industry baseline for browser-based IdP sessions.

## Rolling behaviour

Kratos has no idle-timeout primitive, but `session.earliest_possible_extend` provides equivalent safety. When a `/sessions/whoami` call is made with ≤1h remaining on the session, Kratos extends the session expiry to 24h from that moment. The SPAs already call `/sessions/whoami` on every page load, so active users transparently keep their session. Inactive users (no app activity for ~23h) are asked to log in again — which is the intended security boundary.

The 1h window keeps DB writes minimal: at most one extension write per day per active user.

**Key verified against:** Ory Kratos config schema (`session.earliest_possible_extend`), present since v0.13 and confirmed in the schema JSON at `raw.githubusercontent.com/ory/kratos/v0.13.0/embedx/config.schema.json`. This project runs `oryd/kratos:v25.4.0`.

## Verification

```
grep -n "lifespan\|earliest_possible_extend\|720h\|24h" config/kratos/kratos.production.yml config/kratos/kratos.local.yml
```
Both files show `lifespan: 24h` and `earliest_possible_extend: 1h`. No stray `720h`. YAML parses clean (`python3 -c "import yaml; ..."` → `ok`).

Closes #20