### PR TITLE
Enforce least-privilege append-only on audit database

### DIFF
--- a/api/src/audit/audit.datasource.runtime.ts
+++ b/api/src/audit/audit.datasource.runtime.ts
@@ -1,0 +1,36 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { AuditLog } from './audit-log.entity';
+
+/**
+ * Runtime DataSource — compiled to dist/audit/audit.datasource.runtime.js.
+ *
+ * Used ONLY by the one-shot `api-migrate` compose service to apply audit
+ * migrations inside the PRODUCTION image. That image runs `npm ci --only=production`
+ * and removes npm (api/Dockerfile), so it has NO ts-node/typescript and the `.ts`
+ * sources are absent — `npm run migration:run` (the typeorm-ts-node-commonjs
+ * variant in package.json) cannot run there. Instead the migrate service invokes
+ * the plain compiled CLI with the migrator credentials:
+ *
+ *   node node_modules/typeorm/cli.js migration:run \
+ *     -d dist/audit/audit.datasource.runtime.js
+ *
+ * It mirrors audit.datasource.ts but globs COMPILED migrations under dist/. Like
+ * that file it is NEVER imported by the NestJS app (AuditModule uses
+ * TypeOrmModule.forRoot) — it exists purely for the TypeORM CLI.
+ *
+ * synchronize MUST stay false: this DataSource is for migrations only.
+ */
+const AuditRuntimeDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.AUDIT_DB_HOST,
+  port: parseInt(process.env.AUDIT_DB_PORT ?? '5432', 10),
+  username: process.env.AUDIT_DB_USER,
+  password: process.env.AUDIT_DB_PASSWORD,
+  database: process.env.AUDIT_DB_NAME,
+  entities: [AuditLog],
+  migrations: ['dist/audit/migrations/*.js'],
+  synchronize: false,
+});
+
+export default AuditRuntimeDataSource;

--- a/api/src/audit/audit.module.ts
+++ b/api/src/audit/audit.module.ts
@@ -15,10 +15,16 @@ import { CreateAuditLogs1781750293893 } from './migrations/1781750293893-CreateA
  * Schema management: migrations only, in ALL environments.
  * - synchronize: false — never auto-mutate the schema. Use `npm run migration:generate`
  *   to produce a migration and `npm run migration:run` to apply it.
- * - migrationsRun: true — TypeORM runs pending migrations on every boot, so
- *   the table is created automatically in fresh dev/staging/prod environments
- *   without any manual step.
- * - The standalone DataSource for the CLI lives in audit.datasource.ts.
+ * - migrationsRun: false — the RUNTIME app connects as the least-privilege
+ *   `nova_audit_app` role, which holds only INSERT/SELECT on audit_logs and has
+ *   NO DDL. It must never attempt migrations on boot (it would fail). Migrations
+ *   are applied out-of-band by the privileged `nova_audit_migrator` role via the
+ *   one-shot `api-migrate` compose service (profiles: ["migrate"]). This enforces
+ *   append-only at the STORAGE layer: a fully-compromised BFF cannot
+ *   UPDATE/DELETE/TRUNCATE the ledger. See docs/AUDIT_DB_LEAST_PRIVILEGE.md.
+ * - The CLI DataSource for `npm run migration:*` (TS, dev) lives in
+ *   audit.datasource.ts; the compiled runtime one used by api-migrate (prod
+ *   image, no ts-node) lives in audit.datasource.runtime.ts.
  */
 @Module({
   imports: [
@@ -33,7 +39,7 @@ import { CreateAuditLogs1781750293893 } from './migrations/1781750293893-CreateA
       entities: [AuditLog],
       migrations: [CreateAuditLogs1781750293893],
       synchronize: false,
-      migrationsRun: true,
+      migrationsRun: false,
     }),
     TypeOrmModule.forFeature([AuditLog], 'audit'),
   ],

--- a/config/init-sql/create-users.sh
+++ b/config/init-sql/create-users.sh
@@ -25,6 +25,15 @@ BEGIN
     IF NOT EXISTS (SELECT FROM pg_user WHERE usename = 'demo_user') THEN
         CREATE USER demo_user WITH PASSWORD '${DEMO_DB_PASSWORD}';
     END IF;
+    -- Audit DB least-privilege roles (see docs/AUDIT_DB_LEAST_PRIVILEGE.md):
+    --   nova_audit_migrator — DDL/owner, used only by the api-migrate service.
+    --   nova_audit_app      — runtime BFF role: INSERT/SELECT on audit_logs only.
+    IF NOT EXISTS (SELECT FROM pg_user WHERE usename = 'nova_audit_migrator') THEN
+        CREATE USER nova_audit_migrator WITH PASSWORD '${AUDIT_MIGRATOR_PASSWORD}';
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_user WHERE usename = 'nova_audit_app') THEN
+        CREATE USER nova_audit_app WITH PASSWORD '${AUDIT_APP_PASSWORD}';
+    END IF;
 END
 \$\$;
 
@@ -72,4 +81,22 @@ ALTER DEFAULT PRIVILEGES FOR ROLE demo_user IN SCHEMA public
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO demo_user;
 ALTER DEFAULT PRIVILEGES FOR ROLE demo_user IN SCHEMA public
     GRANT USAGE, SELECT ON SEQUENCES TO demo_user;
+EOF
+
+# Audit DB least-privilege grants (nova_audit). On a fresh bootstrap the
+# audit_logs table does not exist yet — it is created later by the api-migrate
+# service running as nova_audit_migrator. So we grant at the SCHEMA level and use
+# ALTER DEFAULT PRIVILEGES so that any table the migrator creates automatically
+# grants INSERT/SELECT (and NOTHING else) to the runtime app role. The app can
+# never UPDATE/DELETE/TRUNCATE the ledger — append-only at the storage layer.
+# NOTE: production roles/grants are bootstrapped MANUALLY (this script is
+# bootstrap-only and never runs in deploy) — see docs/AUDIT_DB_LEAST_PRIVILEGE.md.
+psql -h postgres -U postgres -d nova_audit <<EOF
+REVOKE CONNECT ON DATABASE nova_audit FROM PUBLIC;
+GRANT CONNECT ON DATABASE nova_audit TO nova_audit_app, nova_audit_migrator;
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO nova_audit_app;
+GRANT USAGE, CREATE ON SCHEMA public TO nova_audit_migrator;
+ALTER DEFAULT PRIVILEGES FOR ROLE nova_audit_migrator IN SCHEMA public
+    GRANT INSERT, SELECT ON TABLES TO nova_audit_app;
 EOF

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -314,8 +314,11 @@ services:
       - AUDIT_DB_HOST=postgres
       - AUDIT_DB_PORT=5432
       - AUDIT_DB_NAME=nova_audit
-      - AUDIT_DB_USER=postgres
-      - AUDIT_DB_PASSWORD=${POSTGRES_PASSWORD}
+      # Least-privilege runtime role: INSERT/SELECT on audit_logs only, no DDL,
+      # not table owner. A compromised BFF cannot UPDATE/DELETE/TRUNCATE the
+      # ledger. Migrations run separately via the api-migrate service below.
+      - AUDIT_DB_USER=nova_audit_app
+      - AUDIT_DB_PASSWORD=${AUDIT_APP_PASSWORD}
     networks:
       - apps
       - ory-internal
@@ -325,6 +328,36 @@ services:
       postgres:
         condition: service_healthy
     restart: unless-stopped
+
+  # ── Audit DB migrator (one-shot, profile-gated) ───────────────────────────────
+  # Applies audit migrations as the privileged nova_audit_migrator role. NOT
+  # started by `docker compose up` (profiles: ["migrate"]) — deploy-prod.sh's
+  # `up -d` ignores it. The runtime app (nova_audit_app) has no DDL, so on the
+  # rare occasion a release adds an audit migration, run this MANUALLY on the
+  # host BEFORE deploying that release:
+  #   IMAGE_TAG=vX.Y.Z docker compose --env-file .env.production \
+  #     -f docker-compose.production.yml --profile migrate run --rm api-migrate
+  # See docs/AUDIT_DB_LEAST_PRIVILEGE.md.
+  api-migrate:
+    image: cativo23/nova-id-api:${IMAGE_TAG:?IMAGE_TAG must be set}
+    command:
+      ["node", "node_modules/typeorm/cli.js", "migration:run", "-d", "dist/audit/audit.datasource.runtime.js"]
+    profiles: ["migrate"]
+    env_file:
+      - .env.production
+    environment:
+      - NODE_ENV=production
+      - AUDIT_DB_HOST=postgres
+      - AUDIT_DB_PORT=5432
+      - AUDIT_DB_NAME=nova_audit
+      - AUDIT_DB_USER=nova_audit_migrator
+      - AUDIT_DB_PASSWORD=${AUDIT_MIGRATOR_PASSWORD}
+    networks:
+      - ory-internal
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
 
   # ── Demo Relying-Party Backend ────────────────────────────────────────────────
   # Standalone NestJS service that owns demo_app Postgres and serves the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       HYDRA_DB_PASSWORD: ${HYDRA_DB_PASSWORD}
       KETO_DB_PASSWORD: ${KETO_DB_PASSWORD}
       DEMO_DB_PASSWORD: ${DEMO_DB_PASSWORD}
+      AUDIT_APP_PASSWORD: ${AUDIT_APP_PASSWORD}
+      AUDIT_MIGRATOR_PASSWORD: ${AUDIT_MIGRATOR_PASSWORD}
     command: >
       sh -c "
         until pg_isready -h postgres -U postgres; do sleep 1; done &&
@@ -269,11 +271,13 @@ services:
       - KRATOS_ADMIN_URL=http://kratos:4434
       - KETO_READ_URL=http://keto:4466
       # Audit trail Postgres connection (nova_audit DB on the ory-internal network).
+      # Least-privilege runtime role: INSERT/SELECT only, no DDL (parity with prod).
+      # Migrations run via the api-migrate service below, not on app boot.
       - AUDIT_DB_HOST=postgres
       - AUDIT_DB_PORT=5432
       - AUDIT_DB_NAME=nova_audit
-      - AUDIT_DB_USER=postgres
-      - AUDIT_DB_PASSWORD=${POSTGRES_PASSWORD}
+      - AUDIT_DB_USER=nova_audit_app
+      - AUDIT_DB_PASSWORD=${AUDIT_APP_PASSWORD}
     networks:
       - apps
       - ory-internal
@@ -281,6 +285,37 @@ services:
       - oathkeeper
       - postgres
     restart: unless-stopped
+
+  # ── Audit DB migrator (one-shot, profile-gated) ────────────────────────────
+  # Dev parity for the prod api-migrate service. Since migrationsRun is now off,
+  # the table is not auto-created on app boot. On first setup of a fresh stack
+  # (or after adding an audit migration), run once:
+  #   docker compose --profile migrate run --rm api-migrate
+  # Uses the privileged migrator role; the dev image has ts-node so it runs the
+  # TS migration:run directly. The runtime app (nova_audit_app) has no DDL.
+  api-migrate:
+    build:
+      context: ./api
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./api:/app
+      - /app/node_modules
+    command: sh -c "npm install && npm run migration:run"
+    profiles: ["migrate"]
+    env_file:
+      - .env
+    environment:
+      - NODE_ENV=development
+      - AUDIT_DB_HOST=postgres
+      - AUDIT_DB_PORT=5432
+      - AUDIT_DB_NAME=nova_audit
+      - AUDIT_DB_USER=nova_audit_migrator
+      - AUDIT_DB_PASSWORD=${AUDIT_MIGRATOR_PASSWORD}
+    networks:
+      - ory-internal
+    depends_on:
+      - postgres
+    restart: "no"
 
   # ── Demo Relying-Party Backend ─────────────────────────────────────────────
   # Standalone NestJS service that owns demo_app Postgres and serves the

--- a/docs/AUDIT_DB_LEAST_PRIVILEGE.md
+++ b/docs/AUDIT_DB_LEAST_PRIVILEGE.md
@@ -1,0 +1,125 @@
+# Audit DB Least-Privilege & Storage-Enforced Append-Only
+
+## Problem
+
+The BFF (`api`) used to connect to the `nova_audit` database as the Postgres
+**cluster superuser** (`AUDIT_DB_USER=postgres`). Any RCE/SQLi in the BFF yielded
+a superuser credential over the *entire* cluster (Kratos identities, Hydra OAuth
+secrets, Keto tuples) and could `TRUNCATE` the `audit_logs` ledger meant to detect
+such tampering. Append-only was enforced only at the application layer
+(`api/src/audit/audit.service.ts` omits update/delete).
+
+## Design — two roles, no superuser
+
+On the `nova_audit` database only:
+
+| Role | Login | Purpose | Privileges |
+|---|---|---|---|
+| `nova_audit_migrator` | yes | Deploy-time DDL only | Owns `audit_logs` + `migrations`; `USAGE, CREATE` on schema. |
+| `nova_audit_app` | yes | BFF runtime | `CONNECT`, schema `USAGE`, `INSERT, SELECT` on `audit_logs`. **No UPDATE/DELETE/TRUNCATE, not owner.** |
+
+The genuine protection is that `nova_audit_app` **does not own** the table — an
+owner can always TRUNCATE regardless of grants. A fully-compromised BFF can
+append (and forge) rows but cannot delete or rewrite history.
+
+Because the runtime role has no DDL, the app no longer runs migrations on boot:
+`audit.module.ts` sets `migrationsRun: false`. Migrations are applied out-of-band
+by the migrator via the one-shot `api-migrate` compose service
+(`profiles: ["migrate"]`), which never starts on a normal `docker compose up`.
+
+In the **prod image** there is no ts-node (devDeps stripped, see `api/Dockerfile`),
+so the migrate service runs the compiled CLI against a JS datasource:
+`node node_modules/typeorm/cli.js migration:run -d dist/audit/audit.datasource.runtime.js`.
+
+## Production bootstrap (MANUAL, once)
+
+Role creation + ownership reassignment requires the **postgres superuser** and
+therefore cannot live in `deploy-prod.sh` (command-restricted, bootstrap-only) or
+in CI (no DB credentials). Run it by hand on the host.
+
+1. Add two strong passwords to `/home/<user>/deploy/nova-id-deploy/.env.production`
+   (keep `chmod 600`):
+   ```
+   AUDIT_APP_PASSWORD=...
+   AUDIT_MIGRATOR_PASSWORD=...
+   ```
+2. Apply the bootstrap SQL as `postgres` against the live `nova_audit` DB. This
+   uses targeted `ALTER TABLE ... OWNER` — **not** `REASSIGN OWNED BY postgres`,
+   which would also reassign ownership of *every other database* postgres owns
+   (kratos/hydra/keto/...):
+   ```bash
+   cd /home/<user>/deploy/nova-id-deploy
+   C=nova-id-deploy-postgres-1
+   PGPW="$(grep -E '^POSTGRES_PASSWORD=' .env.production | cut -d= -f2-)"
+   APW="$(grep -E '^AUDIT_APP_PASSWORD=' .env.production | cut -d= -f2-)"
+   MPW="$(grep -E '^AUDIT_MIGRATOR_PASSWORD=' .env.production | cut -d= -f2-)"
+   docker exec -i -e PGPASSWORD="$PGPW" "$C" psql -U postgres -d nova_audit \
+     -v ON_ERROR_STOP=1 -v app_pw="$APW" -v migrator_pw="$MPW" <<'SQL'
+   CREATE ROLE nova_audit_migrator LOGIN PASSWORD :'migrator_pw';
+   CREATE ROLE nova_audit_app      LOGIN PASSWORD :'app_pw';
+   ALTER TABLE audit_logs OWNER TO nova_audit_migrator;
+   ALTER TABLE migrations OWNER TO nova_audit_migrator;
+   REVOKE ALL ON SCHEMA public FROM PUBLIC;
+   GRANT USAGE ON SCHEMA public TO nova_audit_app;
+   GRANT USAGE, CREATE ON SCHEMA public TO nova_audit_migrator;
+   REVOKE ALL ON ALL TABLES IN SCHEMA public FROM PUBLIC;
+   GRANT INSERT, SELECT ON audit_logs TO nova_audit_app;
+   REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON audit_logs FROM nova_audit_app;
+   ALTER DEFAULT PRIVILEGES FOR ROLE nova_audit_migrator IN SCHEMA public
+     GRANT INSERT, SELECT ON TABLES TO nova_audit_app;
+   REVOKE CONNECT ON DATABASE nova_audit FROM PUBLIC;
+   GRANT CONNECT ON DATABASE nova_audit TO nova_audit_app, nova_audit_migrator;
+   SQL
+   ```
+   > psql variable interpolation (`:'var'`) does NOT work inside a `DO $$ ... $$`
+   > block — use the plain `CREATE ROLE` statements above.
+3. Verify the lockdown:
+   ```bash
+   docker exec -i "$C" psql "host=localhost user=nova_audit_app dbname=nova_audit password=$APW" \
+     -c "INSERT INTO audit_logs(\"actorId\",action) VALUES('bootstrap','test.boot');" \
+     -c "DELETE FROM audit_logs;"   # MUST fail: permission denied
+   ```
+   INSERT must succeed; DELETE/UPDATE/TRUNCATE must all error `permission denied`.
+
+**Ordering matters:** run this bootstrap BEFORE deploying the app build that
+switches `AUDIT_DB_USER` to `nova_audit_app`. The roles sitting unused are
+harmless to the currently-running build (which still connects as `postgres`).
+
+## Normal releases
+
+No audit migration → nothing extra. The app boots as `nova_audit_app` against the
+existing table with `migrationsRun: false`.
+
+## Releases that add an audit migration (rare)
+
+Before tagging/deploying, run the migrator one-shot on the host:
+```bash
+IMAGE_TAG=vX.Y.Z docker compose --env-file .env.production \
+  -f docker-compose.production.yml --profile migrate run --rm api-migrate
+```
+
+## Dev / fresh environments
+
+`config/init-sql/create-users.sh` creates both roles and the schema-level grants
+(table grants flow via `ALTER DEFAULT PRIVILEGES`). After a fresh `docker compose
+up`, create the table once:
+```bash
+docker compose --profile migrate run --rm api-migrate
+```
+
+## Post-deploy check (important)
+
+Audit writes are best-effort — `audit.service.ts` swallows errors. A wrong
+`AUDIT_APP_PASSWORD` will NOT fail smoke tests (`/api/health` does not write
+audit); it manifests as silently-lost audit rows. After deploying, perform one
+admin action and confirm a new row lands in `audit_logs`. Consider a Sentry alert
+on "Audit write failed".
+
+## Residual risk (NOT covered)
+
+- A compromised BFF can still **forge** audit rows (INSERT) — append-only stops
+  deletion, not fabrication.
+- `nova_audit_migrator` / `postgres` (host-root / DB-host compromise) can still
+  TRUNCATE. No hash-chain / WORM / off-box shipping yet.
+- `postgres` superuser still exists; other Ory services remain broadly privileged
+  on their own DBs. This change scopes the **BFF** only.

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -42,6 +42,11 @@ ORY_PASSWORD=$(generate_secret)
 KRATOS_DB_PASSWORD=$(generate_secret)
 HYDRA_DB_PASSWORD=$(generate_secret)
 KETO_DB_PASSWORD=$(generate_secret)
+# Audit DB least-privilege roles (see docs/AUDIT_DB_LEAST_PRIVILEGE.md):
+#   app      — runtime BFF role, INSERT/SELECT on audit_logs only.
+#   migrator — DDL role used only by the api-migrate one-shot service.
+AUDIT_APP_PASSWORD=$(generate_secret)
+AUDIT_MIGRATOR_PASSWORD=$(generate_secret)
 
 # Kratos Secrets
 # cookie:  ≥16 chars — signs session cookies


### PR DESCRIPTION
## Why

The BFF (`api`) connected to `nova_audit` as the Postgres **cluster superuser** (`AUDIT_DB_USER=postgres`). Any RCE/SQLi in the BFF yielded full read/write over **every** database (Kratos identities, Hydra OAuth secrets, Keto tuples) and could `TRUNCATE` the `audit_logs` ledger meant to detect that tampering. Append-only was enforced only in app code.

Surfaced by an adversarial security sweep of the repo (confirmed finding; the JWKS "committed private key" candidate was refuted — it's gitignored).

## What

- **Two roles** on `nova_audit`:
  - `nova_audit_app` — runtime BFF role: `INSERT`/`SELECT` on `audit_logs` only, **not table owner**.
  - `nova_audit_migrator` — DDL/owner, used only by the deploy-time migrator.
- A compromised BFF can no longer `UPDATE`/`DELETE`/`TRUNCATE` the ledger — enforced at the **storage layer**, not just app code.
- `migrationsRun: false` (runtime role has no DDL). Migrations run via a profile-gated one-shot **`api-migrate`** service.
- Prod image strips ts-node, so the migrator uses a **compiled JS datasource** (`audit.datasource.runtime.ts`) + the bundled `typeorm` CLI.
- Dev/fresh parity via `create-users.sh` + `generate-env.sh`.

## Manual step (NOT in CI/CD — superuser required)

Production role creation + ownership reassignment is a **one-time manual** `psql` on the host (see `docs/AUDIT_DB_LEAST_PRIVILEGE.md`). Already applied secrets to `.env.production`; the bootstrap SQL is pending operator run. Used targeted `ALTER TABLE ... OWNER` (NOT `REASSIGN OWNED BY postgres`, which would reassign every other DB).

## Verification

- `docker compose config` valid; `api-migrate` correctly profile-gated (absent from default `up`).
- TS typechecks clean.
- Built the **real prod image** and confirmed `dist/audit/audit.datasource.runtime.js`, `dist/audit/migrations/*.js`, and `node_modules/typeorm/cli.js` all resolve at the expected paths.

## Residual risk

Append-only stops deletion, not fabrication (BFF can still INSERT forged rows); `postgres`/`migrator` can still TRUNCATE; no hash-chain/WORM yet. Scoped to the BFF only.

## Note for CI

No `ci.yml` change needed: unit tests mock the audit repo and `openapi:verify` boots the app without querying `audit_logs`, so `migrationsRun:false` doesn't break it.