### PR TITLE
fix(demo): authenticate the RP via its OAuth2 token (deny now denies)

### DIFF
--- a/config/oathkeeper/oathkeeper.production.yml
+++ b/config/oathkeeper/oathkeeper.production.yml
@@ -77,8 +77,6 @@ authenticators:
     enabled: true
     config:
       introspection_url: http://hydra:4445/oauth2/introspect
-      required_scope:
-        - oauth2
       token_from:
         header: Authorization
 

--- a/config/oathkeeper/rules.local.json
+++ b/config/oathkeeper/rules.local.json
@@ -390,15 +390,6 @@
     },
     "authenticators": [
       {
-        "handler": "cookie_session",
-        "config": {
-          "check_session_url": "http://kratos:4433/sessions/whoami",
-          "preserve_path": true,
-          "extra_from": "@this",
-          "subject_from": "identity.id"
-        }
-      },
-      {
         "handler": "oauth2_introspection"
       }
     ],
@@ -638,15 +629,6 @@
       ]
     },
     "authenticators": [
-      {
-        "handler": "cookie_session",
-        "config": {
-          "check_session_url": "http://kratos:4433/sessions/whoami",
-          "preserve_path": true,
-          "extra_from": "@this",
-          "subject_from": "identity.id"
-        }
-      },
       {
         "handler": "oauth2_introspection"
       }

--- a/config/oathkeeper/rules.local.json
+++ b/config/oathkeeper/rules.local.json
@@ -390,7 +390,7 @@
     },
     "authenticators": [
       {
-        "handler": "oauth2_introspection"
+        "handler": "oauth2_introspection", "config": { "required_scope": ["app:member"] }
       }
     ],
     "authorizer": {
@@ -630,7 +630,7 @@
     },
     "authenticators": [
       {
-        "handler": "oauth2_introspection"
+        "handler": "oauth2_introspection", "config": { "required_scope": ["app:member"] }
       }
     ],
     "authorizer": {

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -494,15 +494,6 @@
     },
     "authenticators": [
       {
-        "handler": "cookie_session",
-        "config": {
-          "check_session_url": "http://kratos:4433/sessions/whoami",
-          "preserve_path": true,
-          "extra_from": "@this",
-          "subject_from": "identity.id"
-        }
-      },
-      {
         "handler": "oauth2_introspection"
       }
     ],

--- a/config/oathkeeper/rules.production.json
+++ b/config/oathkeeper/rules.production.json
@@ -494,7 +494,7 @@
     },
     "authenticators": [
       {
-        "handler": "oauth2_introspection"
+        "handler": "oauth2_introspection", "config": { "required_scope": ["app:member"] }
       }
     ],
     "authorizer": {

--- a/docs/decisions/0006-bff-is-a-token-handler-consolidation-api.md
+++ b/docs/decisions/0006-bff-is-a-token-handler-consolidation-api.md
@@ -6,6 +6,8 @@
 - **Context phase:** Post-A2 (after hardening PRs #33–#36), reviewing the shape of the `api/` tier
 - **Relates to:** [ADR-0001](0001-idp-vs-demo-app-boundary.md), [ADR-0003](0003-three-layer-authorization-model.md), [ADR-0004](0004-per-app-access-enforcement-dual-mode.md), [ADR-0005](0005-generated-api-client-and-workspace.md)
 
+> **Related:** [ADR-0007](0007-demo-rp-authenticates-via-oauth2-token.md) invokes this ADR's documented switch trigger for `frontend-app` (the demo RP); the token-handler pattern below remains in force for the first-party SPAs (`frontend-auth` / `frontend-admin` ↔ the `api/` IdP consolidation API).
+
 ## Context
 
 The `api/` NestJS tier sits between the three Vue SPAs (`frontend-auth`, `frontend-admin`,

--- a/docs/decisions/0007-demo-rp-authenticates-via-oauth2-token.md
+++ b/docs/decisions/0007-demo-rp-authenticates-via-oauth2-token.md
@@ -107,6 +107,9 @@ not used to authenticate demo RP API calls.
 - Refreshing the page clears sessionStorage → user must re-authenticate. Acceptable for a demo; a
   production RP would use refresh tokens via the BFF.
 
+**Scope gate clarification**
+The `/api-test/*` Oathkeeper rules (`api-test` in production and local, `api-test-app-gate` in local) pin `required_scope: [app:member]` per-rule on their `oauth2_introspection` authenticator; the demo token carries `app:member` force-added at consent. The global `oauth2_introspection` authenticator intentionally carries no `required_scope` — the `oauth2` scope it formerly required is not registered on any client and was incorrectly rejecting all tokens. The first-party rules (`protected-admin`, `me-permissions`, `api-roles-bootstrap`) rely on `cookie_session` as primary authenticator, so their `oauth2_introspection` fallback is scope-unrestricted; this is acceptable because Keto subject-level authz (`Platform:nova#administer`) is the real access gate for those routes.
+
 **E2E verification required (post-deploy)**
 1. **Allow flow**: complete login + consent → dashboard appears, `/api-test/me` returns user data.
 2. **Deny flow**: complete login → deny consent → Callback shows error, redirect to `/` shows

--- a/docs/decisions/0007-demo-rp-authenticates-via-oauth2-token.md
+++ b/docs/decisions/0007-demo-rp-authenticates-via-oauth2-token.md
@@ -1,0 +1,131 @@
+# ADR-0007: The demo relying-party authenticates via its OAuth2 token (invokes ADR-0006's switch trigger)
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+- **Deciders:** Carlos (owner), OAuth architect review
+- **Invokes switch trigger of:** [ADR-0006](0006-bff-is-a-token-handler-consolidation-api.md) — for `frontend-app` specifically
+- **Relates to:** [ADR-0001](0001-idp-vs-demo-app-boundary.md), [ADR-0006](0006-bff-is-a-token-handler-consolidation-api.md)
+
+## Context
+
+### ADR-0006's switch trigger has fired for `frontend-app`
+
+ADR-0006 establishes the **token-handler / IdP consolidation API** pattern for the first-party SPAs
+(`frontend-auth`, `frontend-admin` ↔ the `api/` IdP consolidation API). That pattern is correct and
+remains in force for those SPAs: the browser holds no tokens, the Kratos session cookie flows to the
+gateway, Oathkeeper mints a short-lived id_token JWT, and the BFF verifies it server-side.
+
+ADR-0006's "Switch trigger" section reads:
+
+> Revisit this decision and split out a dedicated backend **only if** a frontend (most likely
+> `frontend-app`) becomes a real product application needing its own non-Ory domain backend. At that
+> point the per-frontend BFF cardinality may become justified for that app; the IdP consolidation API
+> stays as-is for the IdP surface.
+
+**That trigger has fired.** In PRs #53/#54, `frontend-app` was extracted from the shared IdP surface
+into a standalone OAuth2 Relying Party with its own backend (`demo-api`). It is no longer a
+first-party SPA calling the IdP consolidation API; it is a third-party-style demo OAuth2 RP calling
+a separate resource server. The correct credential model for a real OAuth2 RP is its own access
+token — not the Kratos SSO cookie the user established with the Authorization Server.
+
+**This ADR applies ONLY to the demo RP path (frontend-app + /api-test/\* Oathkeeper rules +
+demo-api).** The first-party `/api/v1/*` rules and first-party SPAs correctly keep the
+`cookie_session` / token-handler pattern per ADR-0006 and are unchanged.
+
+### The deny-consent bug
+
+The architecture that survived the extraction had a fatal correctness flaw: **`frontend-app`
+discarded the OAuth2 access token after the PKCE callback and relied on the Kratos session cookie
+for all `/api-test/*` calls.** The Oathkeeper `api-test` rule authenticated via `cookie_session`
+(primary) with `oauth2_introspection` as fallback.
+
+Consequence: **denying consent rejected the OAuth2 grant but the Kratos session cookie persisted.**
+Because the RP's authentication decision was based on the cookie (not the token), denying consent had
+no effect on the RP's "logged in" state — the user still saw the dashboard and could call all
+protected `/api-test/*` endpoints. The OAuth2 grant was decorative; it played no role in access
+control.
+
+This violates the core OAuth2 principle that a Relying Party's access to a resource server MUST be
+gated on a valid grant, not on a session the user established with the Authorization Server for an
+unrelated purpose.
+
+### Claims propagation (verified pre-fix — clean swap)
+
+Switching the gateway from `cookie_session` to `oauth2_introspection` is a **clean swap** because the
+BFF already injects the necessary claims into `session.access_token` at consent time
+(`api/src/app.service.ts` — `email`, `name`, `role`, `app_access: true`). Hydra introspection returns
+these under `ext`. The Oathkeeper `id_token` mutator template already has the `Extra.ext.*` fallback
+branch (both `oathkeeper.local.yml` and `oathkeeper.production.yml`). No BFF or demo-api changes are
+required.
+
+### The `required_scope: [oauth2]` mismatch (found during fix)
+
+The production Oathkeeper config had `required_scope: [oauth2]` on the `oauth2_introspection`
+authenticator. The `nova-id-test-app` OAuth client's allowed scopes are
+`openid profile email offline_access` — no `oauth2` scope — so Oathkeeper would have rejected all
+tokens at introspection. The `required_scope` gate was removed; the Keto authorizer
+(`App:nova-id-test-app#access`) is the correct and sufficient access gate.
+
+## Decision
+
+**The demo RP (`frontend-app` + `demo-api`) authenticates its API calls via its OAuth2 access token,
+not the Kratos session cookie.**
+
+Concretely:
+1. `handleOAuthCallback` stores the access token in sessionStorage after a successful PKCE exchange.
+2. `Home.vue` gates the authenticated dashboard on the presence of a stored access token. No token =
+   unauthenticated, regardless of any active Kratos session.
+3. All `/api-test/*` calls send `Authorization: Bearer <access_token>`. `credentials: 'include'` is
+   removed from those calls so the Kratos cookie is not sent.
+4. The Oathkeeper `api-test` rule (in both `rules.local.json` and `rules.production.json`) uses
+   `oauth2_introspection` as the sole authenticator. The local-only `api-test-app-gate` rule gets the
+   same treatment. `cookie_session` is removed from these demo-RP rules.
+5. On deny/error callback, the stored access token is cleared to ensure the user is not authenticated.
+
+**The token-handler pattern of ADR-0006 remains the decision for the first-party SPAs**
+(`frontend-auth` / `frontend-admin` ↔ `api/` IdP consolidation API). Their Oathkeeper rules, the
+BFF `authenticated.guard.ts`, and the shared API client are all unchanged.
+
+The Kratos cookie retains its role for the IdP's own routes (login/consent UI, BFF endpoints). It is
+not used to authenticate demo RP API calls.
+
+## Consequences
+
+**Positive**
+- Denying consent now correctly leaves the user unauthenticated at the demo RP.
+- The RP's auth state is tied to its OAuth2 grant — the standard OAuth2/OIDC model.
+- Cookie scope is narrowed: the Kratos SSO cookie is no longer the credential for a third-party RP's
+  APIs.
+- The `required_scope` misconfiguration is corrected, making the production gateway match the actual
+  client's token capabilities.
+- ADR-0006's switch trigger is exercised cleanly: the first-party pattern remains intact; only the
+  extracted demo RP changes.
+
+**Negative**
+- The access token is stored in sessionStorage. This is appropriate for a demo RP but should be
+  replaced with a token-handler/BFF pattern for any production RP (per ADR-0006).
+- Refreshing the page clears sessionStorage → user must re-authenticate. Acceptable for a demo; a
+  production RP would use refresh tokens via the BFF.
+
+**E2E verification required (post-deploy)**
+1. **Allow flow**: complete login + consent → dashboard appears, `/api-test/me` returns user data.
+2. **Deny flow**: complete login → deny consent → Callback shows error, redirect to `/` shows
+   unauthenticated landing (NOT the dashboard).
+3. **Token-only gate**: clear Kratos cookie in DevTools, keep access token in sessionStorage → API
+   calls still succeed.
+4. **Cookie-only gate (negative)**: clear access token from sessionStorage, keep Kratos cookie →
+   API calls return 401 from Oathkeeper.
+
+## Implementation references
+
+- `frontend-app/src/composables/useHydraOAuth.ts` — `handleOAuthCallback` stores access token; new
+  `getStoredAccessToken`/`clearStoredAccessToken` helpers
+- `frontend-app/src/views/Home.vue` — dashboard gated on stored token; Bearer auth on all
+  `/api-test/*` calls
+- `frontend-app/src/views/Callback.vue` — clears stored token on deny/error
+- `config/oathkeeper/rules.local.json` — `api-test` and `api-test-app-gate` rules (the local config
+  has both): `oauth2_introspection` only
+- `config/oathkeeper/rules.production.json` — `api-test` rule only (production has no separate
+  `api-test-app-gate`; the single `api-test` rule covers the whole `/api-test/` namespace):
+  `oauth2_introspection` only
+- `config/oathkeeper/oathkeeper.production.yml` — removed `required_scope: [oauth2]`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -24,6 +24,7 @@ source-of-truth ruling) and would otherwise be re-litigated later from memory.
 | [0004](0004-per-app-access-enforcement-dual-mode.md) | Enforce per-app access in two coexisting modes, with Keto as the single source of truth | Accepted |
 | [0005](0005-generated-api-client-and-workspace.md) | Generate a typed, tags-split TanStack Query client and distribute it as a pnpm workspace package | Accepted |
 | [0006](0006-bff-is-a-token-handler-consolidation-api.md) | The server tier is a shared token-handler / IdP consolidation API, not a per-frontend BFF | Accepted |
+| [0007](0007-demo-rp-authenticates-via-oauth2-token.md) | The demo relying-party authenticates via its OAuth2 token (invokes ADR-0006's switch trigger) | Accepted |
 
 ## Related decision records (pre-ADR)
 

--- a/frontend-app/src/composables/useHydraOAuth.ts
+++ b/frontend-app/src/composables/useHydraOAuth.ts
@@ -2,9 +2,9 @@
 // OAuth must start at the issuer (api.ory.localhost) so Hydra's CSRF cookie domain matches the
 // redirect-after-login URL; otherwise Hydra returns "No CSRF value available in the session cookie".
 //
-// Token-persistence and client-side claim decoding removed (A1.5, ADR-0002).
-// role/appRole are now read from /api-test/me under the Kratos cookie session the gateway honors.
-// Only the transient PKCE/state/nonce handshake entries remain in sessionStorage.
+// ADR-0007: The access token is stored in sessionStorage after the PKCE callback and used as the
+// sole credential for /api-test/* calls. The Kratos session cookie is NOT used to authenticate
+// demo RP API calls — the gateway api-test rule accepts oauth2_introspection only.
 
 import type { IdTokenClaims, TokenResponse } from '../types'
 
@@ -139,6 +139,9 @@ export async function handleOAuthCallback(code: string, state: string): Promise<
     }
   }
 
+  // Store the access token for use as Bearer credential on /api-test/* calls (ADR-0007).
+  sessionStorage.setItem('nova_id_oauth_access_token', tokens.access_token)
+
   sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'code_verifier')
   sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'state')
   sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'nonce')
@@ -146,6 +149,16 @@ export async function handleOAuthCallback(code: string, state: string): Promise<
   sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'redirect_uri')
 
   return tokens
+}
+
+/** Returns the stored OAuth2 access token, or null if not present. */
+export function getStoredAccessToken(): string | null {
+  return sessionStorage.getItem('nova_id_oauth_access_token')
+}
+
+/** Clears the stored OAuth2 access token (call on logout / deny). */
+export function clearStoredAccessToken(): void {
+  sessionStorage.removeItem('nova_id_oauth_access_token')
 }
 
 export function decodeIdToken(idToken: string): IdTokenClaims {

--- a/frontend-app/src/composables/useHydraOAuth.ts
+++ b/frontend-app/src/composables/useHydraOAuth.ts
@@ -140,7 +140,9 @@ export async function handleOAuthCallback(code: string, state: string): Promise<
   }
 
   // Store the access token for use as Bearer credential on /api-test/* calls (ADR-0007).
-  sessionStorage.setItem('nova_id_oauth_access_token', tokens.access_token)
+  if (tokens.access_token) {
+    sessionStorage.setItem('nova_id_oauth_access_token', tokens.access_token)
+  }
 
   sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'code_verifier')
   sessionStorage.removeItem(OAUTH_STORAGE_PREFIX + 'state')

--- a/frontend-app/src/views/Callback.vue
+++ b/frontend-app/src/views/Callback.vue
@@ -58,7 +58,7 @@
 <script setup lang="ts">
 import { ref, onMounted, inject } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { handleOAuthCallback } from '../composables/useHydraOAuth'
+import { handleOAuthCallback, clearStoredAccessToken } from '../composables/useHydraOAuth'
 
 const router = useRouter()
 const route = useRoute()
@@ -91,6 +91,7 @@ onMounted(async () => {
       router.replace({ path: '/', query: {} })
       return
     }
+    clearStoredAccessToken()
     error.value = msg
     return
   }
@@ -110,6 +111,7 @@ onMounted(async () => {
       router.replace({ path: '/', query: {} })
       return
     }
+    clearStoredAccessToken()
     error.value = errMsg
   }
 })

--- a/frontend-app/src/views/Home.vue
+++ b/frontend-app/src/views/Home.vue
@@ -300,7 +300,6 @@
 import { ref, computed, onMounted, watch, inject, type Ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import NovaLogoIcon from '../components/NovaLogoIcon.vue'
-import { checkSession } from '../composables/useAuth'
 import { initiateOAuthFlow, getStoredAccessToken, clearStoredAccessToken } from '../composables/useHydraOAuth'
 import { getApiTestBaseUrl } from '../composables/useApiTest'
 import type { DemoUser, MeResponse, LogEntry } from '../types'

--- a/frontend-app/src/views/Home.vue
+++ b/frontend-app/src/views/Home.vue
@@ -301,7 +301,7 @@ import { ref, computed, onMounted, watch, inject, type Ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import NovaLogoIcon from '../components/NovaLogoIcon.vue'
 import { checkSession } from '../composables/useAuth'
-import { initiateOAuthFlow } from '../composables/useHydraOAuth'
+import { initiateOAuthFlow, getStoredAccessToken, clearStoredAccessToken } from '../composables/useHydraOAuth'
 import { getApiTestBaseUrl } from '../composables/useApiTest'
 import type { DemoUser, MeResponse, LogEntry } from '../types'
 
@@ -372,11 +372,18 @@ const endpoints: Endpoint[] = [
   { key: 'POST:/api-test/app-admin/configure', method: 'POST', path: '/api-test/app-admin/configure', level: 'app-admin', borderClass: 'border-orange-500/30 bg-orange-500/5', btnClass: 'bg-orange-500/20 text-orange-400 hover:bg-orange-500/30 border border-orange-500/40' }
 ]
 
-async function sessionFromApiMe(): Promise<DemoSession | null> {
+async function sessionFromApiMe(token: string | null): Promise<DemoSession | null> {
+  if (!token) return null
   const url = `${getApiTestBaseUrl()}/me`
   try {
-    const res = await fetch(url, { credentials: 'include' })
-    if (!res.ok) return null
+    const res = await fetch(url, {
+      headers: { 'Authorization': 'Bearer ' + token }
+    })
+    if (!res.ok) {
+      // Token is invalid/expired — clear it so the user is not stuck (ADR-0007).
+      clearStoredAccessToken()
+      return null
+    }
     const me = await res.json() as MeResponse
     const u: DemoUser = me.user ?? (me as unknown as DemoUser)
     if (!u?.id) return null
@@ -400,16 +407,30 @@ async function sessionFromApiMe(): Promise<DemoSession | null> {
 
 async function loadRecentLogs() {
   if (!isAdmin.value) return
+  const token = getStoredAccessToken()
+  if (!token) return
   recentLogsLoading.value = true
   try {
     const baseUrl = getApiTestBaseUrl()
     const opts: RequestInit = {
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json', 'X-Frontend-Source': 'frontend-app' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Frontend-Source': 'frontend-app',
+        'Authorization': 'Bearer ' + token,
+      },
     }
     const res = await fetch(`${baseUrl}/logs?limit=3`, opts)
-    if (res.ok) recentLogs.value = await res.json() as LogEntry[]
-    else recentLogs.value = []
+    if (res.ok) {
+      recentLogs.value = await res.json() as LogEntry[]
+    } else {
+      recentLogs.value = []
+      // 401 = dead/expired token → de-authenticate (ADR-0007). 403 is a legitimate
+      // authz denial, not an auth failure, so the token stays valid.
+      if (res.status === 401) {
+        clearStoredAccessToken()
+        session.value = null
+      }
+    }
   } catch {
     recentLogs.value = []
   } finally {
@@ -419,26 +440,23 @@ async function loadRecentLogs() {
 
 onMounted(async () => {
   try {
-    // Always use the cookie session through the gateway (ADR-0002).
-    // App.vue's refreshAuth() is running concurrently; we read /api-test/me ourselves
-    // so Home has the full user shape (id, email, appRole) for the dashboard.
-    const meSession = await sessionFromApiMe()
+    // Gate authentication on the OAuth2 access token (ADR-0007).
+    // No token → unauthenticated, regardless of any active Kratos session.
+    const storedToken = getStoredAccessToken()
+    if (!storedToken) {
+      session.value = null
+      sessionLoading.value = false
+      return
+    }
+    // Fetch the user profile using the Bearer token.
+    const meSession = await sessionFromApiMe(storedToken)
     if (meSession) {
       session.value = meSession
       if (isAdmin.value) loadRecentLogs()
       return
     }
-    const sessionData = await checkSession()
-    session.value = sessionData?.identity
-      ? {
-          identity: {
-            id: sessionData.identity.id,
-            traits: (sessionData.identity.traits ?? {}) as DemoSession['identity']['traits'],
-            metadata_public: (sessionData.identity.metadata_public ?? null) as DemoSession['identity']['metadata_public']
-          }
-        }
-      : null
-    if (isAdmin.value) loadRecentLogs()
+    // Token present but /me returned null (invalid/expired) — already cleared by sessionFromApiMe.
+    session.value = null
   } catch {
     session.value = null
   } finally {
@@ -487,17 +505,24 @@ async function runTest(ep: Endpoint) {
   try {
     // Test API lives at /api-test/* (use getApiTestBaseUrl, not Oathkeeper /api)
     const url = ep.path.startsWith('/api-test') ? `${getApiTestBaseUrl()}${ep.path.replace(/^\/api-test/, '')}` : ep.path
-    const isSimpleGet = ep.method === 'GET' && (ep.path === '/api-test/health' || ep.path === '/api-test/public')
-    // Always use the Kratos cookie session; the gateway's api-test rule accepts cookie_session (ADR-0002).
+    const isPublicEndpoint = ep.method === 'GET' && (ep.path === '/api-test/health' || ep.path === '/api-test/public')
+    // Public endpoints need no auth. Protected endpoints use Bearer token (ADR-0007).
+    const token = isPublicEndpoint ? null : getStoredAccessToken()
+    if (!isPublicEndpoint && !token) {
+      apiError.value = 'Not authenticated. Please sign in first.'
+      return
+    }
     const headers: Record<string, string> = {}
     const options: RequestInit = {
       method: ep.method,
-      credentials: 'include',
       headers
     }
-    if (!isSimpleGet) {
+    if (!isPublicEndpoint) {
+      // token is guaranteed non-null here by the guard above.
+      const safeToken = token as string
       headers['Content-Type'] = 'application/json'
       headers['X-Frontend-Source'] = 'frontend-app'
+      headers['Authorization'] = 'Bearer ' + safeToken
     }
     if (ep.method === 'POST' || ep.method === 'PUT') {
       options.body = JSON.stringify({ timestamp: new Date().toISOString(), source: 'frontend-app' })


### PR DESCRIPTION
Fixes the demo-RP bug where **denying OAuth consent still let you in**: the RP was deciding "logged in" from the Kratos SSO cookie (via /api-test/me) instead of its OAuth2 token, so the grant was decorative.

**Fix (scoped to the demo RP only):**
- frontend-app: stores the access token from the PKCE callback and gates the dashboard on it (not the cookie); sends `Authorization: Bearer` on /api-test/*; clears token on deny/error.
- Oathkeeper: /api-test/* now authenticated by `oauth2_introspection` (Hydra token), `cookie_session` removed; `required_scope: [app:member]` pinned per-rule (first-party /api/v1 rules untouched).
- ADR-0007 invokes ADR-0006's switch trigger (frontend-app became a standalone RP); ADR-0006 stays Accepted for the first-party SPAs.

Claims-propagation verified: consent-accept sets session.access_token={email,name,role}, surfaced via introspection `ext` → id_token mutator → demo-api unchanged. Reviewed (Opus) APPROVED-WITH-FIXES; fixes applied. Needs live deny/allow E2E after deploy.