### PR TITLE
fix(auth): skip Kratos login when a session already exists during OAuth

### DIFF
--- a/frontend-auth/src/views/Login.vue
+++ b/frontend-auth/src/views/Login.vue
@@ -235,7 +235,7 @@ import { useRouter, useRoute } from 'vue-router'
 import type { LocationQuery, LocationQueryValue } from 'vue-router'
 import type { UpdateLoginFlowBody } from '@ory/client'
 import NovaLogoIcon from '../components/NovaLogoIcon.vue'
-import { createLoginFlow, getLoginFlow, updateLoginFlow } from '../composables/useAuth'
+import { checkSession, createLoginFlow, getLoginFlow, updateLoginFlow } from '../composables/useAuth'
 import type { FlowLike, HttpErrorLike, ContinueWithLike } from '../types/flow'
 import type { UiNodeLike } from '../utils/uiNodes'
 import { logger, errMessage } from '../utils/logger'
@@ -282,6 +282,16 @@ onMounted(async () => {
       // OAuth/Hydra flow: after Kratos login, land on hydra-callback to accept Hydra login and complete OAuth
       const base = import.meta.env.VITE_AUTH_URL || window.location.origin
       const returnUrl = `${base}/auth/hydra-callback?login_challenge=${encodeURIComponent(loginChallenge)}`
+      // If a Kratos session already exists, creating a new login flow would make
+      // Kratos reject with 400 "you are already logged in" and dump the user on
+      // the generic error page. Skip Kratos login entirely and go straight to
+      // hydra-callback, which accepts the Hydra login via the BFF using the
+      // existing session cookie (honoring Hydra's `skip`).
+      const existingSession = await checkSession().catch(() => null)
+      if (existingSession) {
+        window.location.href = returnUrl
+        return
+      }
       intendedReturnUrl.value = returnUrl
       flow.value = await createLoginFlow(returnUrl)
     } else {


### PR DESCRIPTION
## Why

When Hydra routes to the login UI (`frontend-auth`) with a `login_challenge` but the user **already has a valid Kratos session**, `Login.vue` unconditionally called `createBrowserLoginFlow`. Kratos rejects that with `400 "you are already logged in (forgot ?refresh=true?)"`, the error bubbles to the `catch`, and the user lands on the generic `/auth/error` page — which misleadingly reads *"Something went wrong. If you need to verify your email…"*.

Reproducible 100% of the time when an active session exists at the start of an OAuth flow (e.g. open the demo app while already signed in). Surfaced during the v1.2.3 audit-write E2E.

## What

In the `login_challenge` branch of `onMounted`, check `checkSession()` first:
- **Session exists** → skip Kratos login entirely; redirect straight to `/auth/hydra-callback?login_challenge=…`, which accepts the Hydra login via the BFF (`POST /hydra-accept-login`) using the existing session cookie and honoring Hydra's `skip`.
- **No session** → unchanged (`createLoginFlow`).

The BFF `acceptHydraLogin` already resolves the subject from the cookie-authenticated user (and honors `skip`), so no backend change is needed.

## Scope
- Single file: `frontend-auth/src/views/Login.vue` (+9 lines, one guard).
- First-party login path only; no change to Kratos config, BFF, or the no-session flow.

## Verification
- `vue-tsc --noEmit` clean.
- Live prod E2E to follow: trigger OAuth from the demo app **with an active Kratos session** → should reach consent directly (no `/auth/error`).