### PR TITLE
fix(api): meaningful errors for expired/invalid Hydra challenges

### DIFF
--- a/api/src/app.service.ts
+++ b/api/src/app.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
+import { toHttpExceptionFromOry } from './common/ory-error';
 import { HydraService } from './ory/hydra.service';
 import { KetoService } from './ory/keto.service';
 import { AuditService } from './audit/audit.service';
@@ -56,7 +57,7 @@ export class AppService {
       });
     } catch (error) {
       this.logger.error('Error accepting Hydra login:', error.response?.data || error.message);
-      throw error;
+      throw toHttpExceptionFromOry(error);
     }
   }
 
@@ -125,7 +126,7 @@ export class AppService {
       });
     } catch (error) {
       this.logger.error('Error accepting Hydra consent:', error.response?.data || error.message);
-      throw error;
+      throw toHttpExceptionFromOry(error);
     }
   }
 
@@ -154,7 +155,7 @@ export class AppService {
       };
     } catch (error) {
       this.logger.error('Error fetching consent request:', error.response?.data || error.message);
-      throw error;
+      throw toHttpExceptionFromOry(error);
     }
   }
 
@@ -190,7 +191,7 @@ export class AppService {
       return { redirect_to: result.redirect_to };
     } catch (error) {
       this.logger.error('Error rejecting consent:', error.response?.data || error.message);
-      throw error;
+      throw toHttpExceptionFromOry(error);
     }
   }
 }

--- a/api/src/common/ory-error.spec.ts
+++ b/api/src/common/ory-error.spec.ts
@@ -1,0 +1,57 @@
+import {
+  HttpException,
+  GoneException,
+  BadGatewayException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { toHttpExceptionFromOry } from './ory-error';
+
+/** Build a minimal AxiosError-like object for the mapper under test. */
+function axiosErr(status: number, data: unknown) {
+  return { isAxiosError: true, response: { status, data } } as unknown;
+}
+
+describe('toHttpExceptionFromOry', () => {
+  it('maps an expired consent challenge (401 + "expired") to 410 Gone with a clear message', () => {
+    const ex = toHttpExceptionFromOry(
+      axiosErr(401, {
+        error: 'request_unauthorized',
+        error_description:
+          'The request could not be authorized. The consent request has expired, please try again.',
+      }),
+    );
+    expect(ex).toBeInstanceOf(GoneException);
+    expect(ex.getStatus()).toBe(410);
+    const body = ex.getResponse() as { code: string; message: string };
+    expect(body.code).toBe('oauth_challenge_expired');
+    expect(body.message).toMatch(/expired/i);
+  });
+
+  it('maps a not-found challenge (404) to 410 Gone invalid', () => {
+    const ex = toHttpExceptionFromOry(axiosErr(404, { error: 'not_found' }));
+    expect(ex).toBeInstanceOf(GoneException);
+    const body = ex.getResponse() as { code: string };
+    expect(body.code).toBe('oauth_challenge_invalid');
+  });
+
+  it('maps any other Ory error to 502 Bad Gateway, surfacing the description', () => {
+    const ex = toHttpExceptionFromOry(
+      axiosErr(500, { error_description: 'boom upstream' }),
+    );
+    expect(ex).toBeInstanceOf(BadGatewayException);
+    expect(ex.getStatus()).toBe(502);
+    const body = ex.getResponse() as { message: string };
+    expect(body.message).toContain('boom upstream');
+  });
+
+  it('passes existing HttpExceptions through unchanged (e.g. the IDOR ForbiddenException)', () => {
+    const forbidden = new ForbiddenException('Consent challenge does not belong to current user');
+    expect(toHttpExceptionFromOry(forbidden)).toBe(forbidden);
+  });
+
+  it('falls back to a generic 502 when the error carries no Ory detail', () => {
+    const ex = toHttpExceptionFromOry(new Error('socket hang up'));
+    expect(ex).toBeInstanceOf(BadGatewayException);
+    expect(ex).toBeInstanceOf(HttpException);
+  });
+});

--- a/api/src/common/ory-error.ts
+++ b/api/src/common/ory-error.ts
@@ -1,0 +1,62 @@
+import {
+  HttpException,
+  GoneException,
+  BadGatewayException,
+} from '@nestjs/common';
+import type { AxiosError } from 'axios';
+
+/**
+ * Maps an error raised by an Ory admin API call (Hydra/Kratos/Keto) into a
+ * meaningful Nest HttpException.
+ *
+ * Without this, the raw AxiosError propagates and Nest's default filter turns
+ * it into a generic `500 Internal server error`, hiding the real reason from
+ * the user — most commonly an expired login/consent challenge (Hydra returns
+ * `401 request_unauthorized` with "The consent request has expired" once the
+ * challenge TTL, default 30m, elapses). The SPA renders `response.data.message`,
+ * so surfacing a clear message here is enough to fix the UX end-to-end.
+ *
+ * Existing HttpExceptions (e.g. the ForbiddenException from the IDOR/ownership
+ * check) are passed through unchanged.
+ */
+export function toHttpExceptionFromOry(error: unknown): HttpException {
+  if (error instanceof HttpException) return error;
+
+  const axiosErr = error as AxiosError<{
+    error?: string;
+    error_description?: string;
+  }>;
+  const status = axiosErr?.response?.status;
+  const data = axiosErr?.response?.data;
+  const oryMessage = data?.error_description ?? data?.error;
+
+  // Expired login/consent challenge: Hydra answers 401 with an "...has expired"
+  // description. 410 Gone is the correct semantic — the challenge no longer
+  // exists and the client must restart the OAuth flow.
+  if (status === 401 && /expired/i.test(oryMessage ?? '')) {
+    return new GoneException({
+      statusCode: 410,
+      code: 'oauth_challenge_expired',
+      message: 'Your authorization session expired. Please start signing in again.',
+    });
+  }
+
+  // Challenge not found or already consumed.
+  if (status === 404 || status === 410) {
+    return new GoneException({
+      statusCode: 410,
+      code: 'oauth_challenge_invalid',
+      message: 'This authorization request is no longer valid. Please start signing in again.',
+    });
+  }
+
+  // Any other upstream Ory failure: surface Ory's own description (when present)
+  // as a 502 so the cause is visible, never a bare 500.
+  return new BadGatewayException({
+    statusCode: 502,
+    code: 'ory_upstream_error',
+    message: oryMessage
+      ? `Identity provider error: ${oryMessage}`
+      : 'The identity provider returned an unexpected error. Please try again.',
+  });
+}


### PR DESCRIPTION
## Why

When you click **Allow** (or Deny) on a consent screen that has been open past Hydra's challenge TTL (default **30 min**), Hydra returns `401 request_unauthorized — "The consent request has expired"`. The BFF caught that Ory `AxiosError` and re-threw it raw, so Nest's default filter turned it into a generic **`500 Internal server error`** with no explanation — the user has no idea what happened or what to do.

Surfaced live during the v1.2.4 SSO verification: left the consent screen open during a conversation, clicked Allow, got a bare 500.

## What

New pure mapper `api/src/common/ory-error.ts` → `toHttpExceptionFromOry(error)`:

| Upstream (Ory) | Mapped to | Message |
|---|---|---|
| `401` + "expired" | **410 Gone** (`code: oauth_challenge_expired`) | "Your authorization session expired. Please start signing in again." |
| `404` / `410` | **410 Gone** (`code: oauth_challenge_invalid`) | "This authorization request is no longer valid…" |
| any other Ory error | **502 Bad Gateway** (`code: ory_upstream_error`) | surfaces Ory's `error_description` |
| existing `HttpException` (IDOR `ForbiddenException`) | passed through unchanged | — |

Applied in all four Hydra-facing `AppService` methods: `acceptHydraLogin`, `acceptHydraConsent`, `getHydraConsentInfo`, `rejectHydraConsent`.

The SPA already renders `response.data.message` (`Consent.vue`, `HydraCallback.vue`), so no frontend change is needed — the consent screen now shows the real reason instead of "Internal server error".

## Scope & tests
- API only: 1 new util + 1 spec + the 4 catch blocks. No DTO/endpoint change → `openapi.json` unchanged.
- `ory-error.spec.ts`: 5 cases (expired→410, not-found→410, other→502, HttpException passthrough, no-detail fallback). All green; existing `app.service.spec` (15) still pass. `nest build` clean.

## Follow-up idea (not in this PR)
Add a "Start over" action on the consent error state so the user can re-initiate without manually going back to the RP.