### PR TITLE
Align .env.example with least-privilege audit roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,16 +17,19 @@ ORY_PASSWORD=CHANGE_ME_32_CHARS_MIN
 KRATOS_DB_PASSWORD=CHANGE_ME_32_CHARS_MIN
 HYDRA_DB_PASSWORD=CHANGE_ME_32_CHARS_MIN
 KETO_DB_PASSWORD=CHANGE_ME_32_CHARS_MIN
+AUDIT_APP_PASSWORD=CHANGE_ME_32_CHARS_MIN
+AUDIT_MIGRATOR_PASSWORD=CHANGE_ME_32_CHARS_MIN
 
 # Audit DB Configuration (BFF → nova_audit Postgres)
 # In local dev these resolve to the postgres service on the ory-internal Docker network.
-# AUDIT_DB_PASSWORD should match POSTGRES_PASSWORD (uses the postgres superuser in local dev;
-# provision a dedicated audit_user with INSERT-only grants on audit_logs in production).
+# Least-privilege: the BFF runtime connects as nova_audit_app (INSERT/SELECT on
+# audit_logs only); migrations run as nova_audit_migrator via the api-migrate
+# one-shot service. Set AUDIT_APP_PASSWORD / AUDIT_MIGRATOR_PASSWORD above;
+# compose maps AUDIT_DB_PASSWORD per service. See docs/AUDIT_DB_LEAST_PRIVILEGE.md.
 AUDIT_DB_HOST=postgres
 AUDIT_DB_PORT=5432
 AUDIT_DB_NAME=nova_audit
-AUDIT_DB_USER=postgres
-AUDIT_DB_PASSWORD=CHANGE_ME_32_CHARS_MIN
+AUDIT_DB_USER=nova_audit_app
 
 # Demo App DB Configuration (BFF → demo_app Postgres)
 # demo_user is a least-privilege role created by postgres-init (no access to IdP DBs).


### PR DESCRIPTION
Follow-up to #68. Adds `AUDIT_APP_PASSWORD` / `AUDIT_MIGRATOR_PASSWORD` to the template, switches `AUDIT_DB_USER` to `nova_audit_app`, and replaces the stale "match POSTGRES_PASSWORD" note. `.env.example` was blocked by a `.env*` read guard in #68's session, so it lagged the functional changes (`generate-env.sh`, compose) that already shipped.

Template-only; no secrets, no runtime impact.