### PR TITLE
fix: resolve latent lint issues (demo-api require, api e2e tsconfig)

### DIFF
--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["node_modules", "dist", "test"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,

--- a/demo-api/src/guards/demo-authenticated.guard.spec.ts
+++ b/demo-api/src/guards/demo-authenticated.guard.spec.ts
@@ -1,6 +1,11 @@
 import { UnauthorizedException } from "@nestjs/common";
 import { DemoAuthenticatedGuard } from "./demo-authenticated.guard";
 
+// TS-native CommonJS import syntax: keeps a live, mutable binding to the
+// actual module.exports object (unlike `import * as jwtLib`, whose namespace
+// object is read-only), which `jest.spyOn(jwtLib, "verify")` below relies on.
+import jwtLib = require("jsonwebtoken");
+
 /**
  * DemoAuthenticatedGuard unit tests.
  *
@@ -90,7 +95,6 @@ describe("DemoAuthenticatedGuard", () => {
   });
 
   it("sets request.user from verified JWT claims", async () => {
-    const jwtLib = require("jsonwebtoken");
     const payload = {
       sub: "user-abc",
       email: "alice@nova.test",
@@ -102,7 +106,7 @@ describe("DemoAuthenticatedGuard", () => {
     };
 
     const token = jwtLib.sign(payload, "test-secret", {
-      header: { kid: "test-kid" },
+      keyid: "test-kid",
     });
 
     const guard = makeGuard();
@@ -127,7 +131,6 @@ describe("DemoAuthenticatedGuard", () => {
   });
 
   it("rejects a token missing the sub claim", async () => {
-    const jwtLib = require("jsonwebtoken");
     const payload = {
       email: "nosubject@nova.test",
       iss: "https://id.cativo.dev/",
@@ -135,7 +138,7 @@ describe("DemoAuthenticatedGuard", () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
     const token = jwtLib.sign(payload, "test-secret", {
-      header: { kid: "test-kid" },
+      keyid: "test-kid",
     });
 
     const guard = makeGuard();


### PR DESCRIPTION
## Summary
- **demo-api**: `demo-authenticated.guard.spec.ts` used inline `require("jsonwebtoken")` twice for `jest.spyOn` targets, tripping `@typescript-eslint/no-var-requires`. Replaced with a top-level `import jwtLib = require("jsonwebtoken")` (TS-native static import syntax, not a runtime `require()` call) which keeps the mutable module binding `jest.spyOn` needs — `import * as jwtLib` doesn't work here because its namespace object is read-only. Also swapped the `sign()` `header: { kid }` option for the equivalent typed `keyid` option, since the now-type-checked call otherwise fails to compile against `@types/jsonwebtoken`.
- **api**: eslint's `parserOptions.project` pointed at `tsconfig.json`, which excluded `test/`, so linting `test/setup-e2e.ts` and `test/app.e2e-spec.ts` errored with "file not found in project". Moved the `test` exclusion into a new `tsconfig.build.json` (which `nest build` now uses) and removed it from the base `tsconfig.json` so eslint's project covers `test/` too.

Neither issue was caught by CI — `ci.yml` doesn't run `npm run lint` for either service — so both went unnoticed until now. No runtime behavior changes.

## Test plan
- [x] `npm run lint` clean (0 errors) in both `demo-api` and `api`, including `test/**` files in `api`
- [x] `npm test` green in both `demo-api` (24/24) and `api` (84/84)
- [x] `npm run build` succeeds in both `demo-api` and `api`; `dist/` confirmed to still exclude `test/**` and `*.spec.ts`