### PR TITLE
chore(ci): bump GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
     name: Workspace (typecheck + build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -101,10 +101,10 @@ jobs:
       run:
         working-directory: ./api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -166,10 +166,10 @@ jobs:
       run:
         working-directory: ./demo-api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -226,7 +226,7 @@ jobs:
     name: Build production images (build-only, no push)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Real build gate: a broken Dockerfile or build-arg fails the PR here.
       # Frontend build-args mirror .github/workflows/release.yml exactly.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Install SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.POLARIS2_SSH_KEY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -77,10 +77,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
       # Build once with load:true so Trivy scans the exact bytes we later push.
       # No second build — the push step pushes this same local image.
       - name: Build api image (load locally — Trivy scans before any push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./api
           file: ./api/Dockerfile
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -142,17 +142,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Build once with load:true so Trivy scans the exact bytes we later push.
       - name: Build demo-api image (load locally — Trivy scans before any push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./demo-api
           file: ./demo-api/Dockerfile
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -206,17 +206,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Build once with load:true so Trivy scans the exact bytes we later push.
       - name: Build frontend-auth image (load locally — Trivy scans before any push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.frontend.prod
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -275,17 +275,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Build once with load:true so Trivy scans the exact bytes we later push.
       - name: Build frontend-admin image (load locally — Trivy scans before any push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.frontend.prod
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -345,17 +345,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Build once with load:true so Trivy scans the exact bytes we later push.
       - name: Build frontend-app image (load locally — Trivy scans before any push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.frontend.prod


### PR DESCRIPTION
GitHub Actions runners now warn that several pinned actions target the deprecated Node 20 runtime and are being force-run on Node 24. This bumps each flagged action to the latest major version confirmed (via each action's `action.yml` `using:` field) to run natively on `node24`.

| Action | Old | New | Verified |
|---|---|---|---|
| `actions/checkout` | v4 | v7 | `action.yml` at `v7.0.0` → `using: node24` |
| `actions/setup-node` | v4 | v6 | `action.yml` at `v6.4.0` → `using: node24` |
| `pnpm/action-setup` | v4 | v6 | `action.yml` at `v6.0.9` → `using: node24` |
| `docker/build-push-action` | v5 | v7 | `action.yml` at `v7.3.0` → `using: node24` |
| `docker/login-action` | v3 | v4 | `action.yml` at `v4.4.0` → `using: node24` |
| `docker/setup-buildx-action` | v3 | v4 | `action.yml` at `v4.2.0` → `using: node24` |
| `webfactory/ssh-agent` | v0.9.0 | v0.10.0 | `action.yml` at `v0.10.0` → `using: node24` |

`aquasecurity/trivy-action@v0.36.0` was left untouched — it wasn't flagged in the deprecation warnings and is out of scope.

**Note:** `webfactory/ssh-agent` only runs in `deploy.yml`'s deploy job, which is gated on release/tag push — this PR's own CI does not exercise that bump. It's low risk (just an SSH agent setup) but will only be validated on the next real deploy.

## Test plan
- [x] `grep -rn "uses:"` across `.github/workflows/` to confirm every flagged action is bumped consistently across all files
- [ ] PR CI (checkout/setup-node/pnpm/docker actions all exercised) passes green
- [ ] No Node 20 deprecation warnings appear in the new CI run's annotations